### PR TITLE
Add YAML files re-writing upon cluster setup

### DIFF
--- a/scripts/setup/create_multinode.sh
+++ b/scripts/setup/create_multinode.sh
@@ -164,6 +164,14 @@ function extend_CIDR() {
 
     shift # make argument list only contain worker nodes (drops master node)
 
+    #* Setup github authentication.
+    ACCESS_TOKEH="$(cat $GITHUB_TOKEN)"
+
+    server_exec $MASTER_NODE 'echo -en "\n\n" | ssh-keygen -t rsa'
+    server_exec $MASTER_NODE 'ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts'
+
+    server_exec $MASTER_NODE 'curl -H "Authorization: token '"$ACCESS_TOKEH"'" --data "{\"title\":\"'"key:\$(hostname)"'\",\"key\":\"'"\$(cat ~/.ssh/id_rsa.pub)"'\"}" https://api.github.com/user/keys'
+
     #* Get loader and dependencies.
     server_exec $MASTER_NODE "git clone --branch=$LOADER_BRANCH git@github.com:eth-easl/loader.git"
     server_exec $MASTER_NODE 'echo -en "\n\n" | sudo apt-get install python3-pip python-dev'
@@ -179,14 +187,6 @@ function extend_CIDR() {
     #* Notify the master that all nodes have been registered
     server_exec $MASTER_NODE 'tmux send -t master "y" ENTER'
     echo "Master node $MASTER_NODE finalised."
-
-    #* Setup github authentication.
-    ACCESS_TOKEH="$(cat $GITHUB_TOKEN)"
-
-    server_exec $MASTER_NODE 'echo -en "\n\n" | ssh-keygen -t rsa'
-    server_exec $MASTER_NODE 'ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts'
-
-    server_exec $MASTER_NODE 'curl -H "Authorization: token '"$ACCESS_TOKEH"'" --data "{\"title\":\"'"key:\$(hostname)"'\",\"key\":\"'"\$(cat ~/.ssh/id_rsa.pub)"'\"}" https://api.github.com/user/keys'
 
     source $DIR/taint.sh
 

--- a/scripts/setup/create_singlenode_container.sh
+++ b/scripts/setup/create_singlenode_container.sh
@@ -14,6 +14,13 @@ server_exec() {
     server_exec 'sudo DEBIAN_FRONTEND=noninteractive apt-get autoremove' 
     server_exec "git clone --branch=$VHIVE_BRANCH https://github.com/ease-lab/vhive"
 
+    # Setup github authentication.
+    ACCESS_TOKEH="$(cat $GITHUB_TOKEN)"
+    server_exec 'echo -en "\n\n" | ssh-keygen -t rsa'
+    server_exec 'ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts'
+    server_exec 'curl -H "Authorization: token '"$ACCESS_TOKEH"'" --data "{\"title\":\"'"key:\$(hostname)"'\",\"key\":\"'"\$(cat ~/.ssh/id_rsa.pub)"'\"}" https://api.github.com/user/keys'
+    # server_exec 'sleep 5'
+
     # Get loader and dependencies.
     server_exec "git clone --branch=$LOADER_BRANCH git@github.com:eth-easl/loader.git"
     server_exec 'echo -en "\n\n" | sudo apt-get install python3-pip python-dev'
@@ -38,20 +45,6 @@ server_exec() {
     server_exec 'rm go1.17*'
     server_exec 'echo "export PATH=$PATH:/usr/local/go/bin" >> ~/.profile'
     server_exec 'source ~/.profile'
-
-    # Setup github authentication.
-    ACCESS_TOKEH="$(cat $GITHUB_TOKEN)"
-
-    server_exec 'echo -en "\n\n" | ssh-keygen -t rsa'
-    server_exec 'ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts'
-
-    server_exec 'curl -H "Authorization: token '"$ACCESS_TOKEH"'" --data "{\"title\":\"'"key:\$(hostname)"'\",\"key\":\"'"\$(cat ~/.ssh/id_rsa.pub)"'\"}" https://api.github.com/user/keys'
-    # server_exec 'sleep 5'
-
-    # Get loader and dependencies.
-    server_exec "git clone --branch=$LOADER_BRANCH git@github.com:eth-easl/loader.git"
-    server_exec 'echo -en "\n\n" | sudo apt-get install python3-pip python-dev'
-    server_exec 'cd; cd loader; pip install -r config/requirements.txt'
 
     $DIR/expose_infra_metrics.sh $SERVER
 

--- a/scripts/setup/create_singlenode_container.sh
+++ b/scripts/setup/create_singlenode_container.sh
@@ -10,9 +10,18 @@ server_exec() {
 }
 
 {
-    # Spin up vHive under container mode.
+    # Set up up vHive in the container mode.
     server_exec 'sudo DEBIAN_FRONTEND=noninteractive apt-get autoremove' 
     server_exec "git clone --branch=$VHIVE_BRANCH https://github.com/ease-lab/vhive"
+
+    # Get loader and dependencies.
+    server_exec "git clone --branch=$LOADER_BRANCH git@github.com:eth-easl/loader.git"
+    server_exec 'echo -en "\n\n" | sudo apt-get install python3-pip python-dev'
+    server_exec 'cd; cd loader; pip install -r config/requirements.txt'
+
+    # Rewrite the YAML files for Knative and Istio in the vHive repo
+    server_exec 'cd; ./loader/scripts/setup/rewrite_yaml_files.sh'
+
     server_exec 'cd vhive; ./scripts/cloudlab/setup_node.sh stock-only'
     server_exec 'tmux new -s runner -d'
     server_exec 'tmux new -s kwatch -d'
@@ -23,7 +32,7 @@ server_exec() {
     server_exec 'cd vhive; ./scripts/cluster/create_one_node_cluster.sh stock-only'
     server_exec 'tmux send-keys -t cluster "watch -n 0.5 kubectl get pods -A" ENTER'
 
-    # Update golang.
+    # Update Golang.
     server_exec 'wget -q https://dl.google.com/go/go1.17.linux-amd64.tar.gz'
     server_exec 'sudo rm -rf /usr/local/go && sudo tar -C /usr/local/ -xzf go1.17.linux-amd64.tar.gz'
     server_exec 'rm go1.17*'
@@ -35,7 +44,6 @@ server_exec() {
 
     server_exec 'echo -en "\n\n" | ssh-keygen -t rsa'
     server_exec 'ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts'
-    # server_exec 'RSA=$(cat ~/.ssh/id_rsa.pub)'
 
     server_exec 'curl -H "Authorization: token '"$ACCESS_TOKEH"'" --data "{\"title\":\"'"key:\$(hostname)"'\",\"key\":\"'"\$(cat ~/.ssh/id_rsa.pub)"'\"}" https://api.github.com/user/keys'
     # server_exec 'sleep 5'
@@ -48,7 +56,7 @@ server_exec() {
     $DIR/expose_infra_metrics.sh $SERVER
 
     #* Disable turbo boost.
-    server_exec './vhive/scripts/turbo_boost.sh disable'
+    server_exec './vhive/scripts/utils/turbo_boost.sh disable'
     #* Disable hyperthreading.
     server_exec 'echo off | sudo tee /sys/devices/system/cpu/smt/control'
     #* Create CGroup.

--- a/scripts/setup/create_singlenode_container.sh
+++ b/scripts/setup/create_singlenode_container.sh
@@ -26,7 +26,8 @@ server_exec() {
     server_exec 'echo -en "\n\n" | sudo apt-get install python3-pip python-dev'
     server_exec 'cd; cd loader; pip install -r config/requirements.txt'
 
-    # Rewrite the YAML files for Knative and Istio in the vHive repo
+    # Install YQ and rewrite the YAML files for Knative and Istio in the vHive repo
+    server_exec 'sudo wget https://github.com/mikefarah/yq/releases/download/v4.27.3/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq'
     server_exec 'cd; ./loader/scripts/setup/rewrite_yaml_files.sh'
 
     server_exec 'cd vhive; ./scripts/cloudlab/setup_node.sh stock-only'

--- a/scripts/setup/rewrite_yaml_files.sh
+++ b/scripts/setup/rewrite_yaml_files.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+pushd $HOME/vhive > /dev/null
+
+
+# 1. Update IP address range 
+
+pushd configs/metallb/ > /dev/null
+
+cat metallb-configmap.yaml | head -n 11 > metallb-configmap-mod.yaml
+echo "      - 10.200.3.4-10.200.3.24" >> metallb-configmap-mod.yaml
+    mv metallb-configmap-mod.yaml metallb-configmap.yaml
+
+popd > /dev/null
+
+
+# 1. Update CPU and memory limits. 
+#    NOTE: The commands depend on the order of containers in the YAML file.
+
+pushd configs/istio/ > /dev/null
+
+cat net-istio.yaml | \
+    yq e '
+    (
+        select(
+        .spec.template.metadata.labels.app == "net-istio-controller"
+        or .spec.template.metadata.labels.app == "net-istio-webhook"
+    )
+    | .spec.template.spec.containers[0].resources.limits.cpu ) = 3' \
+    | yq e '
+    (
+        select(
+        .spec.template.metadata.labels.app == "net-istio-controller"
+        or .spec.template.metadata.labels.app == "net-istio-webhook"
+    )
+    | .spec.template.spec.containers[0].resources.limits.memory ) = "10Gi"' \
+    > net-istio-mod.yaml && \
+    mv net-istio-mod.yaml net-istio.yaml
+
+popd > /dev/null
+
+
+# 1. Change calico-node's container env variable CALICO_IPV4POOL_CIDR
+#    NOTE: This command creates duplicate entries if ran several times 
+#          but it should be ok (no easy fix).
+# 2. Add arguments to run flammeld
+#    NOTE: The commands depend on the order of containers in the YAML file.
+
+pushd configs/calico > /dev/null
+
+cat canal.yaml | \
+    yq e '
+    (
+        select(
+        .spec.template.spec.containers[].name == "calico-node"
+    )
+    | .spec.template.spec.containers[0].env ) |= . +
+    [ {"name": "CALICO_IPV4POOL_CIDR", "value": "10.168.0.0/16"} ]' \
+    | yq e '
+    (
+        select(
+        .spec.template.spec.containers[].name == "kube-flannel"
+    )
+    | .spec.template.spec.containers[1].command ) = ["/opt/bin/flanneld"]' \
+    | yq e '
+    (
+        select(
+        .spec.template.spec.containers[].name == "kube-flannel"
+    )
+    | .spec.template.spec.containers[1].args ) |= 
+    [ "--ip-masq", "--kube-subnet-mgr", "--iface=$IFACE"]' \
+    > canal-mod.yaml && \
+    mv canal-mod.yaml canal.yaml
+
+popd > /dev/null
+
+
+# 1. Enforce placement on the master node
+# 2a,b. Update CPU and memory limits. 
+#    NOTE: The commands depend on the order of containers in the YAML file.
+# 3. Remove the affinity constraint
+
+for platform in stock vhive
+do
+    pushd configs/knative_yamls/$platform > /dev/null
+    
+    cat serving-core.yaml | \
+        yq e '
+        (
+            select(
+            .spec.template.metadata.labels.app == "activator"
+            or .spec.template.metadata.labels.app == "autoscaler"
+            or .spec.template.metadata.labels.app == "controller"
+            or .spec.template.metadata.labels.app == "domain-mapping"
+            or .spec.template.metadata.labels.app == "domainmapping-webhook"
+            or .spec.template.metadata.labels.app == "webhook"
+        )
+        | .spec.template.spec ) += {"nodeSelector": {"kubernetes.io/hostname":"$MASTER_NODE_NAME"}}' \
+        | yq e '
+        (
+            select(
+            .spec.template.metadata.labels.app == "activator"
+            or .spec.template.metadata.labels.app == "autoscaler"
+            or .spec.template.metadata.labels.app == "controller"
+            or .spec.template.metadata.labels.app == "domain-mapping"
+            or .spec.template.metadata.labels.app == "domainmapping-webhook"
+            or .spec.template.metadata.labels.app == "webhook"
+        )
+        | .spec.template.spec.containers[0].resources.limits.cpu ) = 3' \
+        | yq e '
+        (
+            select(
+            .spec.template.metadata.labels.app == "activator"
+            or .spec.template.metadata.labels.app == "autoscaler"
+            or .spec.template.metadata.labels.app == "controller"
+            or .spec.template.metadata.labels.app == "domain-mapping"
+            or .spec.template.metadata.labels.app == "domainmapping-webhook"
+            or .spec.template.metadata.labels.app == "webhook"
+        )
+        | .spec.template.spec.containers[0].resources.limits.memory ) = "10Gi"' \
+        | yq e '
+        (
+            select(
+            .spec.template.metadata.labels.app == "activator"
+            or .spec.template.metadata.labels.app == "autoscaler"
+            or .spec.template.metadata.labels.app == "controller"
+            or .spec.template.metadata.labels.app == "domain-mapping"
+            or .spec.template.metadata.labels.app == "domainmapping-webhook"
+            or .spec.template.metadata.labels.app == "webhook"
+        )
+        | .spec.template.spec ) |= with_entries(select(.key == "affinity" | not))' \
+        > serving-core-mod.yaml && \
+        mv serving-core-mod.yaml serving-core.yaml
+    
+    popd > /dev/null
+done
+
+popd > /dev/null # leave the vhive dir

--- a/scripts/setup/setup.cfg
+++ b/scripts/setup/setup.cfg
@@ -1,5 +1,5 @@
-VHIVE_BRANCH='hy'
-LOADER_BRANCH='main'
+VHIVE_BRANCH='yaml_manifests'
+LOADER_BRANCH='yaml_gen'
 CLUSTER_MODE='container' # choose from {container, firecracker, firecracker_snapshots}
 PODS_PER_NODE=240
 GITHUB_TOKEN=$HOME/.git_token_loader


### PR DESCRIPTION
Previously, we stored Knative/Istio YAML files with our modifications in place, which is prone to errors. Hence, I wrote a generator, which is based on [YQ](https://mikefarah.gitbook.io/yq/) YAML processor, that applies various updates to YAML files. For example, setting CPU and memory quotas, nodeSelector, CIDR.

More details can be found [in the vHive PR](https://github.com/ease-lab/vhive/pull/594), which contains the pre-requisite changes.