### PR TITLE
Fix issues #23 #44

### DIFF
--- a/cmd/load.go
+++ b/cmd/load.go
@@ -46,7 +46,7 @@ var (
 	funcDuration = flag.Int("funcDuration", 1000, "Function execution duration in ms (under `stress` mode)")
 	funcMemory   = flag.Int("funcMemory", 170, "Function memeory in MiB(under `stress` mode)")
 
-	iatDistribution = flag.String("iatDistribution", "poisson", "Choose a distribution from [poisson, uniform, equidistant]")
+	iatDistribution = flag.String("iatDistribution", "exponential", "Choose a distribution from [exponential, uniform, equidistant]")
 
 	seed  = flag.Int64("seed", 42, "Random seed for the generator")
 	print = flag.String("print", "all", "Choose a mode from [all, debug, info]")
@@ -102,8 +102,8 @@ func main() {
 	}
 
 	switch *iatDistribution {
-	case "poisson":
-		iatType = gen.Poisson
+	case "exponential":
+		iatType = gen.Exponential
 	case "uniform":
 		iatType = gen.Uniform
 	case "equidistant":
@@ -217,11 +217,11 @@ func runStressMode() {
 
 func runBurstMode() {
 	var functions []tc.Function
-	functionsTable := make(map[string]tc.Function)
+	functionTable := make(map[string]tc.Function)
 	initialScales := []int{1, 1, 0}
 
 	for _, f := range []string{"steady", "bursty", "victim"} {
-		functionsTable[f] = tc.Function{
+		functionTable[f] = tc.Function{
 			Name:     f + "-func",
 			Endpoint: tc.GetFuncEndpoint(f + "-func"),
 			RuntimeStats: tc.FunctionRuntimeStats{
@@ -233,12 +233,12 @@ func runBurstMode() {
 				Percentile100: 0,
 			},
 		}
-		functions = append(functions, functionsTable[f])
+		functions = append(functions, functionTable[f])
 	}
 
 	fc.DeployFunctions(functions, serviceConfigPath, initialScales, *isPartiallyPanic)
 
-	gen.GenerateBurstLoads(*rpsEnd, *burstTarget, *duration, functionsTable, iatType, *withTracing)
+	gen.GenerateBurstLoads(*rpsEnd, *burstTarget, *duration, functionTable, iatType, *withTracing)
 }
 
 func runColdStartMode() {

--- a/pkg/generate/trace_load.go
+++ b/pkg/generate/trace_load.go
@@ -42,8 +42,8 @@ func GenerateTraceLoads(
 		}
 	}()
 
-	/** Launch a scraper that updates Knative states every 2s (max. interval). */
-	scrape_kn := time.NewTicker(time.Second * 2)
+	/** Launch a scraper that updates Knative states every 15s (max. interval). */
+	scrape_kn := time.NewTicker(time.Second * 15)
 	go func() {
 		for {
 			<-scrape_kn.C
@@ -52,7 +52,7 @@ func GenerateTraceLoads(
 	}()
 
 	/** Launch a scraper for getting cold-start count. */
-	scrape_scales := time.NewTicker(time.Second * 1)
+	scrape_scales := time.NewTicker(time.Second * 60)
 	go func() {
 		for {
 			<-scrape_scales.C
@@ -72,7 +72,6 @@ func GenerateTraceLoads(
 
 trace_gen:
 	for ; minute < int(totalDurationMinutes); minute++ {
-		tick := 0
 		var iats []float64
 		var numFuncInvokedThisMinute int64 = 0
 
@@ -84,7 +83,8 @@ trace_gen:
 			continue
 		}
 
-		iats = GenerateOneMinuteInterarrivalTimesInMicro(
+		iats = GenerateInterarrivalTimesInMicro(
+			60,
 			numInvocationsThisMinute,
 			iatDistribution,
 		)
@@ -93,50 +93,60 @@ trace_gen:
 		/** Set up timer to bound the one-minute invocation. */
 		iterStart := time.Now()
 		timeout := time.After(time.Duration(60) * time.Second)
-		interval := time.Duration(iats[tick]) * time.Microsecond
+		interval := time.Duration(iats[0]) * time.Microsecond
 		ticker := time.NewTicker(interval)
 		done := make(chan bool, 2) // Two semaphores, one for timer, one for early completion.
+		tick := 0
 
+		wg.Add(1)
 		/** Launch a timer. */
 		go func() {
+			defer wg.Done()
+
 			t := <-timeout
 			log.Warn("(Slot finished)\t", t.Format(time.StampMilli), "\tMinute Nbr. ", minute)
 			ticker.Stop()
 			done <- true
 		}()
 
+	this_minute_gen:
 		for {
 			select {
 			case <-ticker.C:
 
+				wg.Add(1)
+				go func(m int, nxt int, phase int, rps int, interval int64) {
+					defer wg.Done()
+
+					atomic.AddInt64(&numFuncInvokedThisMinute, 1)
+					funcIndx := invocationsEachMinute[m][nxt]
+					function := functions[funcIndx]
+
+					runtimeRequested, memoryRequested := GenerateExecutionSpecs(function)
+					success, execRecord := fc.Invoke(function, runtimeRequested, memoryRequested, withTracing)
+
+					if success {
+						atomic.AddInt64(&successCountTotal, 1)
+					} else {
+						atomic.AddInt64(&failureCountTotal, 1)
+					}
+					execRecord.Phase = phase
+					execRecord.Interval = interval
+					execRecord.Rps = rps
+					execRecord.ColdStartCount = coldStartGauge
+					collector.ReportExecution(execRecord, clusterUsage, knStats)
+
+				}(minute, tick, phaseIdx, rps, interval.Milliseconds()) //* Push vars onto the stack to prevent racing.
+
+				tick++
 				if tick >= numInvocationsThisMinute {
 					//* Finished before timeout.
 					log.Info("Finish target invocation early at Minute slot ", minute, " Itr. ", tick)
 					done <- true
 				} else {
-					go func(m int, nxt int, phase int, rps int, interval int64) {
-						defer wg.Done()
-						wg.Add(1)
-
-						atomic.AddInt64(&numFuncInvokedThisMinute, 1)
-						funcIndx := invocationsEachMinute[m][nxt]
-						function := functions[funcIndx]
-
-						runtimeRequested, memoryRequested := GenerateExecutionSpecs(function)
-						success, execRecord := fc.Invoke(function, runtimeRequested, memoryRequested, withTracing)
-
-						if success {
-							atomic.AddInt64(&successCountTotal, 1)
-						} else {
-							atomic.AddInt64(&failureCountTotal, 1)
-						}
-						execRecord.Phase = phase
-						execRecord.Interval = interval
-						execRecord.Rps = rps
-						execRecord.ColdStartCount = coldStartGauge
-						collector.ReportExecution(execRecord, clusterUsage, knStats)
-
-					}(minute, tick, phaseIdx, rps, interval.Milliseconds()) //* Push vars onto the stack to prevent racing.
+					//* Load the next inter-arrival time.
+					interval = time.Duration(iats[tick]) * time.Microsecond
+					ticker = time.NewTicker(interval)
 				}
 
 			case <-done:
@@ -166,20 +176,9 @@ trace_gen:
 					break trace_gen
 				}
 
-				goto next_minute
+				break this_minute_gen
 			}
-
-			tick++
-			//* Load the next inter-arrival time.
-			d := 1
-			if tick < len(iats) {
-				d = int(iats[tick])
-			}
-
-			interval = time.Duration(d) * time.Microsecond
-			ticker = time.NewTicker(interval)
 		}
-	next_minute:
 	}
 	log.Info("\tFinished invoking all functions.")
 

--- a/pkg/test/generate_test.go
+++ b/pkg/test/generate_test.go
@@ -24,32 +24,46 @@ func TestGenCheckOverload(t *testing.T) {
 }
 
 func TestGenerateIat(t *testing.T) {
+	totalNumInvocations := 30_000
+	oneMinuteInMicro := 60_000_000.0
+	halfMinuteInMicro := oneMinuteInMicro / 2
 
-	invocationsPerMinute := 20_000
-	iats := gen.GenerateOneMinuteInterarrivalTimesInMicro(invocationsPerMinute, gen.Equidistant)
+	/** Testing Equidistant */
+	iats := gen.GenerateInterarrivalTimesInMicro(60, totalNumInvocations, gen.Equidistant)
 	duration, _ := stats.Sum(stats.LoadRawData(iats))
 
 	assert.Equal(t, iats[rand.Intn(len(iats))], iats[rand.Intn(len(iats))])
-	assert.Equal(t, invocationsPerMinute, len(iats))
-	assert.Greater(t, 60_000_000.0, duration)
+	assert.Equal(t, totalNumInvocations, len(iats))
+	assert.Greater(t, oneMinuteInMicro, duration)
+	t.Log("One-minute duration (equidistant): ", duration)
 
 	for _, iat := range iats {
 		assert.GreaterOrEqual(t, iat, 1.0)
 	}
 
-	iats = gen.GenerateOneMinuteInterarrivalTimesInMicro(invocationsPerMinute, gen.Poisson)
+	/** Testing Exponential */
+	iats = gen.GenerateInterarrivalTimesInMicro(60, totalNumInvocations, gen.Exponential)
 	duration, _ = stats.Sum(stats.LoadRawData(iats))
 
-	assert.Equal(t, invocationsPerMinute, len(iats))
-	assert.Greater(t, 60_000_000.0, duration)
+	assert.Equal(t, totalNumInvocations, len(iats))
+	assert.Greater(t, oneMinuteInMicro, duration)
+	t.Log("One-minute duration (exponential): ", duration)
 
 	for _, iat := range iats {
 		assert.GreaterOrEqual(t, iat, 1.0)
 	}
 
-	iats = gen.GenerateOneMinuteInterarrivalTimesInMicro(0, gen.Poisson)
+	iats = gen.GenerateInterarrivalTimesInMicro(60, 0, gen.Exponential)
 	assert.Equal(t, 0, len(iats))
-	t.Log(iats)
+	// t.Log(iats)
+
+	/** Testing shorter intervals. */
+	iats = gen.GenerateInterarrivalTimesInMicro(30, totalNumInvocations, gen.Uniform)
+	duration, _ = stats.Sum(stats.LoadRawData(iats))
+
+	assert.Equal(t, totalNumInvocations, len(iats))
+	assert.Greater(t, halfMinuteInMicro, duration)
+	t.Log("Half-minute duration (uniform): ", duration)
 }
 
 func TestShuffling(t *testing.T) {

--- a/scripts/setup/expose_infra_metrics.sh
+++ b/scripts/setup/expose_infra_metrics.sh
@@ -29,17 +29,17 @@ server_exec() {
 	server_exec 'cd loader; sudo kubeadm upgrade apply --config config/kubeadm_init.yaml --ignore-preflight-errors all --force --v=7'
 
 
-	#* Change scrape intervals to 2s for all used monitors.
-	server_exec "sudo kubectl -n monitoring patch ServiceMonitor prometheus-kube-prometheus-apiserver --type json -p '[{"op": "add", "path": "/spec/endpoints/0/interval", "value": "2s"}]'"
-	server_exec "sudo kubectl -n monitoring patch ServiceMonitor prometheus-kube-prometheus-coredns --type json -p '[{"op": "add", "path": "/spec/endpoints/0/interval", "value": "2s"}]'"
-	server_exec "sudo kubectl -n monitoring patch ServiceMonitor prometheus-kube-prometheus-kube-controller-manager --type json -p '[{"op": "add", "path": "/spec/endpoints/0/interval", "value": "2s"}]'"
-	server_exec "sudo kubectl -n monitoring patch ServiceMonitor prometheus-kube-prometheus-kube-etcd --type json -p '[{"op": "add", "path": "/spec/endpoints/0/interval", "value": "2s"}]'"
-	server_exec "sudo kubectl -n monitoring patch ServiceMonitor prometheus-kube-prometheus-kube-proxy --type json -p '[{"op": "add", "path": "/spec/endpoints/0/interval", "value": "2s"}]'"
-	server_exec "sudo kubectl -n monitoring patch ServiceMonitor prometheus-kube-prometheus-kube-scheduler --type json -p '[{"op": "add", "path": "/spec/endpoints/0/interval", "value": "2s"}]'"
-	server_exec "sudo kubectl -n monitoring patch ServiceMonitor prometheus-kube-prometheus-operator --type json -p '[{"op": "add", "path": "/spec/endpoints/0/interval", "value": "2s"}]'"
-	server_exec "sudo kubectl -n monitoring patch ServiceMonitor prometheus-kube-prometheus-prometheus --type json -p '[{"op": "add", "path": "/spec/endpoints/0/interval", "value": "2s"}]'"
-	server_exec "sudo kubectl -n monitoring patch ServiceMonitor prometheus-kube-state-metrics --type json -p '[{"op": "add", "path": "/spec/endpoints/0/interval", "value": "2s"}]'"
-	server_exec "sudo kubectl -n monitoring patch ServiceMonitor prometheus-prometheus-node-exporter --type json -p '[{"op": "add", "path": "/spec/endpoints/0/interval", "value": "2s"}]'"
+	#* Change scrape intervals to 15s for all used monitors.
+	server_exec "sudo kubectl -n monitoring patch ServiceMonitor prometheus-kube-prometheus-apiserver --type json -p '[{"op": "add", "path": "/spec/endpoints/0/interval", "value": "15s"}]'"
+	server_exec "sudo kubectl -n monitoring patch ServiceMonitor prometheus-kube-prometheus-coredns --type json -p '[{"op": "add", "path": "/spec/endpoints/0/interval", "value": "15s"}]'"
+	server_exec "sudo kubectl -n monitoring patch ServiceMonitor prometheus-kube-prometheus-kube-controller-manager --type json -p '[{"op": "add", "path": "/spec/endpoints/0/interval", "value": "15s"}]'"
+	server_exec "sudo kubectl -n monitoring patch ServiceMonitor prometheus-kube-prometheus-kube-etcd --type json -p '[{"op": "add", "path": "/spec/endpoints/0/interval", "value": "15s"}]'"
+	server_exec "sudo kubectl -n monitoring patch ServiceMonitor prometheus-kube-prometheus-kube-proxy --type json -p '[{"op": "add", "path": "/spec/endpoints/0/interval", "value": "15s"}]'"
+	server_exec "sudo kubectl -n monitoring patch ServiceMonitor prometheus-kube-prometheus-kube-scheduler --type json -p '[{"op": "add", "path": "/spec/endpoints/0/interval", "value": "15s"}]'"
+	server_exec "sudo kubectl -n monitoring patch ServiceMonitor prometheus-kube-prometheus-operator --type json -p '[{"op": "add", "path": "/spec/endpoints/0/interval", "value": "15s"}]'"
+	server_exec "sudo kubectl -n monitoring patch ServiceMonitor prometheus-kube-prometheus-prometheus --type json -p '[{"op": "add", "path": "/spec/endpoints/0/interval", "value": "15s"}]'"
+	server_exec "sudo kubectl -n monitoring patch ServiceMonitor prometheus-kube-state-metrics --type json -p '[{"op": "add", "path": "/spec/endpoints/0/interval", "value": "15s"}]'"
+	server_exec "sudo kubectl -n monitoring patch ServiceMonitor prometheus-prometheus-node-exporter --type json -p '[{"op": "add", "path": "/spec/endpoints/0/interval", "value": "15s"}]'"
 
 	sleep 5s
 	#* Set up port prometheus panel (infinite loops are important to circumvent kubectl timeout in the middle of experiments).


### PR DESCRIPTION
## Summary

This PR aims to fix #23 #44. 

## Implementation Notes :hammer_and_pick:

* There were improper counting of invocations.
* Generating IATs should take into account the time required for goroutine to spawn and invocation to fire. 

## External Dependencies :four_leaf_clover:

* Updated some dependencies.

## Breaking API Changes :warning:

* The interface of IAT generator function has changed slightly -- now it generates arrival times for any given durations as opposed to 1 min, because the RPS mode needs different intervals sometimes. @cvetkovic @Lightxyz 
