### PR TITLE
Added end-to-end CI atop of konk (k8s in docker)

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,75 @@
+name: End-to-End Tests
+
+on: [push]
+#on:
+#  schedule:
+#    - cron: "0 9 * * 1"
+#  workflow_dispatch:
+#  push:
+#    branches: [main, loader_unit_tests]
+#  pull_request:
+#    branches: [main, loader_unit_tests]
+
+env:
+  GOOS: linux
+  GO111MODULE: on
+
+jobs:
+  test-knative:
+    name: Test Knative Deployment
+    env:
+      KIND_VERSION: v0.14.0
+      K8S_VERSION: v1.23
+      YAML_DIR: workloads/container
+
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          [
+            trace_func_go,
+          ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          lfs: "true"
+      - name: Checkout LFS objects
+        run: git lfs checkout
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+
+      - name: Create k8s Kind Cluster
+        run: bash ./scripts/konk-ci/01-kind.sh
+
+      - name: Install Serving
+        run: bash ./scripts/konk-ci/02-serving.sh
+
+      - name: Install Kourier
+        run: bash ./scripts/konk-ci/02-kourier.sh
+
+      - name: Setup domain and autoscaler
+        run: |
+          INGRESS_HOST="127.0.0.1"
+          KNATIVE_DOMAIN=$INGRESS_HOST.sslip.io
+          kubectl patch configmap -n knative-serving config-domain -p "{\"data\": {\"$KNATIVE_DOMAIN\": \"\"}}"
+          kubectl patch configmap -n knative-serving config-autoscaler -p "{\"data\": {\"allow-zero-initial-scale\": \"true\"}}"
+
+      - name: Build and run loader
+        run: go run cmd/loader.go --config cmd/config.json
+
+      - name: Print logs
+        if: ${{ always() }}
+        run: |
+          set -x
+          container_list=$(kubectl get pods -n default -o jsonpath="{.items[*].spec.containers[*].name}")
+          for container_name in $container_list
+          do
+            kubectl logs -n default -c $container_name -l serving.knative.dev/service=${{ matrix.service }}
+          done
+      - name: Down
+        if: ${{ always() }}
+        run: |
+          kn service delete --all

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,17 +1,18 @@
-name: Loader integration tests
+name: Unit tests
 
-on:
-  push:
-    branches: [ main ]
-    paths-ignore:
-      - 'docs/**'
-      - '**.md'
-  pull_request:
-    branches: [ main ]
-    paths-ignore:
-      - 'docs/**'
-      - '**.md'
-  workflow_dispatch:
+on: push
+#on:
+#  push:
+#    branches: [ main ]
+#    paths-ignore:
+#      - 'docs/**'
+#      - '**.md'
+#  pull_request:
+#    branches: [ main ]
+#    paths-ignore:
+#      - 'docs/**'
+#      - '**.md'
+#  workflow_dispatch:
 
 env:
   GOOS: linux
@@ -23,6 +24,14 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
+      matrix:
+        module:
+          [
+              config,
+              driver,
+              generator,
+              trace,
+          ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -35,11 +44,17 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-          cache: 'pip' # caching pip dependencies
-      - run: pip install -r ./requirements.txt
+
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.txt') }}
+
+      - name: Install requirements
+        run: pip install -r ./requirements.txt
 
       - name: Build loader
-        run: make build
+        run: go build cmd/loader.go
 
       - name: Run loader tests
-        run: make test
+        run: go test  -v -cover -race ./pkg/${{ matrix.module }}

--- a/scripts/konk-ci/01-kind.sh
+++ b/scripts/konk-ci/01-kind.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+kindVersion=$(kind version);
+K8S_VERSION=${k8sVersion:-v1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9}
+KIND_BASE=${KIND_BASE:-kindest/node}
+CLUSTER_NAME=${KIND_CLUSTER_NAME:-knative}
+
+echo "KinD version is ${kindVersion}"
+if [[ ! $kindVersion =~ "${KIND_VERSION}." ]]; then
+  echo "WARNING: Please make sure you are using KinD version ${KIND_VERSION}.x, download from https://github.com/kubernetes-sigs/kind/releases"
+fi
+
+REPLY=continue
+KIND_EXIST="$(kind get clusters -q | grep ${CLUSTER_NAME} || true)"
+if [[ ${KIND_EXIST} ]] ; then
+  echo "WARNING: Knative Cluster kind-${CLUSTER_NAME} already installed -> delete"
+  kind delete cluster --name ${CLUSTER_NAME}
+fi
+
+echo "Using image ${KIND_BASE}:${K8S_VERSION}"
+KIND_CLUSTER=$(mktemp)
+cat <<EOF | kind create cluster --name ${CLUSTER_NAME} --wait 120s --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  image: ${KIND_BASE}:${K8S_VERSION}
+  extraPortMappings:
+  - containerPort: 31080 # expose port 31380 of the node to port 80 on the host, later to be use by kourier or contour ingress
+    listenAddress: 127.0.0.1
+    hostPort: 80
+EOF

--- a/scripts/konk-ci/02-contour.sh
+++ b/scripts/konk-ci/02-contour.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+set -u
+
+KNATIVE_NET_CONTOUR_VERSION=${KNATIVE_NET_CONTOUR_VERSION:-1.4.0}
+
+## INSTALL CONTOUR
+n=0
+until [ $n -ge 2 ]; do
+  kubectl apply -f https://github.com/knative-sandbox/net-contour/releases/download/knative-v${KNATIVE_NET_CONTOUR_VERSION}/contour.yaml  && break
+  n=$[$n+1]
+  sleep 5
+done
+kubectl wait --for=condition=Established --all crd
+kubectl wait pod --timeout=-1s --for=condition=Ready -l '!job-name' -n contour-internal
+kubectl wait pod --timeout=-1s --for=condition=Ready -l '!job-name' -n contour-external
+
+## INSTALL NET CONTOUR
+n=0
+until [ $n -ge 2 ]; do
+  kubectl apply -f https://github.com/knative-sandbox/net-contour/releases/download/knative-v${KNATIVE_NET_CONTOUR_VERSION}/net-contour.yaml && break
+  n=$[$n+1]
+  sleep 5
+done
+# deployment for net-contour gets deployed to namespace knative-serving
+kubectl wait pod --timeout=-1s --for=condition=Ready -l '!job-name' -n knative-serving
+
+# Configure Knative to use this ingress
+kubectl patch configmap/config-network \
+  --namespace knative-serving \
+  --type merge \
+  --patch '{"data":{"ingress.class":"contour.ingress.networking.knative.dev"}}'
+
+
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Service
+metadata:
+  name: contour-ingress
+  namespace: contour-external
+  labels:
+    networking.knative.dev/ingress-provider: contour
+spec:
+  type: NodePort
+  selector:
+    app: envoy
+  ports:
+    - name: http
+      nodePort: 31080
+      port: 80
+      targetPort: 8080
+EOF

--- a/scripts/konk-ci/02-kourier.sh
+++ b/scripts/konk-ci/02-kourier.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+set -u
+
+KNATIVE_NET_KOURIER_VERSION=${KNATIVE_NET_KOURIER_VERSION:-1.4.0}
+
+## INSTALL KOURIER
+n=0
+until [ $n -ge 3 ]; do
+  kubectl apply -f https://github.com/knative-sandbox/net-kourier/releases/download/knative-v${KNATIVE_NET_KOURIER_VERSION}/kourier.yaml  && break
+  echo "Kourier failed to install on first try"
+  n=$[$n+1]
+  sleep 10
+done
+kubectl wait pod --timeout=-1s --for=condition=Ready -l '!job-name' -n kourier-system
+kubectl wait pod --timeout=-1s --for=condition=Ready -l '!job-name' -n knative-serving
+
+# Configure Knative to use this ingress
+kubectl patch configmap/config-network \
+  --namespace knative-serving \
+  --type merge \
+  --patch '{"data":{"ingress.class":"kourier.ingress.networking.knative.dev"}}'
+
+
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Service
+metadata:
+  name: kourier-ingress
+  namespace: kourier-system
+  labels:
+    networking.knative.dev/ingress-provider: kourier
+spec:
+  type: NodePort
+  selector:
+    app: 3scale-kourier-gateway
+  ports:
+    - name: http2
+      nodePort: 31080
+      port: 80
+      targetPort: 8080
+EOF

--- a/scripts/konk-ci/02-serving.sh
+++ b/scripts/konk-ci/02-serving.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+set -u
+
+KNATIVE_VERSION=${KNATIVE_VERSION:-1.4.0}
+
+wget -q https://github.com/knative/client/releases/download/knative-v${KNATIVE_VERSION}/kn-linux-amd64
+mv kn-linux-amd64 kn && chmod +x kn
+mv kn /usr/local/bin
+
+n=0
+set +e
+until [ $n -ge 2 ]; do
+  kubectl apply -f https://github.com/knative/serving/releases/download/knative-v${KNATIVE_VERSION}/serving-crds.yaml && break
+  echo "Serving CRDs failed to install on first try"
+  n=$[$n+1]
+  sleep 5
+done
+set -e
+kubectl wait --for=condition=Established --all crd
+
+n=0
+set +e
+until [ $n -ge 2 ]; do
+  kubectl apply -f https://github.com/knative/serving/releases/download/knative-v${KNATIVE_VERSION}/serving-core.yaml && break
+  echo "Serving Core failed to install on first try"
+  n=$[$n+1]
+  sleep 5
+done
+set -e
+kubectl wait pod --timeout=-1s --for=condition=Ready -l '!job-name' -n knative-serving
+


### PR DESCRIPTION
## Summary

Introduces a workflow that runs Knative 1.4 atop of stock GitHub-hosted runners. 

## External Dependencies :four_leaf_clover:

* KinD project

## Breaking API Changes :warning:

* n/a
