### PR TITLE
Change cluster metrics format to json and add pod metrics

### DIFF
--- a/pkg/metric/record.go
+++ b/pkg/metric/record.go
@@ -104,6 +104,8 @@ type ClusterUsage struct {
 	CpuPctActiveAvg float64  `csv:"cpu_pct_active_avg" json:"cpu_pct_active_avg"`
 	Memory          []string `csv:"memory" json:"memory"`
 	MemoryPctAvg    float64  `csv:"memory_pct" json:"memory_pct"`
+	PodCpu          []string `csv:"pod_cpu" json:"pod_cpu"`
+	PodMemory       []string `csv:"pod_memory" json:"pod_mem"`
 }
 
 type AdfResult struct {

--- a/pkg/metric/scrape_infra.py
+++ b/pkg/metric/scrape_infra.py
@@ -8,6 +8,7 @@ if __name__ == "__main__":
     cmd_get_loader_pct = ['bash', 'scripts/metrics/get_loader_cpu_pct.sh']
     cmd_get_abs_vals = ['bash', 'scripts/metrics/get_node_stats_abs.sh']
     cmd_get_pcts = ['bash', 'scripts/metrics/get_node_stats_percent.sh']
+    cmd_get_pod_abs_vals = ['bash', 'scripts/metrics/get_pod_stats_abs.sh']
 
     result = {
         "master_cpu_pct": 0,
@@ -18,6 +19,8 @@ if __name__ == "__main__":
         "cpu_pct_max": 0,
         "memory": [],
         "memory_pct": 0,
+        "pod_cpu": [],
+        "pod_mem": [],
     }
 
     loader_cpu_pct, loader_mem_pct = list(
@@ -27,6 +30,7 @@ if __name__ == "__main__":
 
     abs_out = subprocess.check_output(cmd_get_abs_vals).decode("utf-8")[:-1]
     pcts_out = subprocess.check_output(cmd_get_pcts).decode("utf-8")
+    pod_abs_out = subprocess.check_output(cmd_get_pod_abs_vals).decode("utf-8")[:-1]
 
     cpus = []
     mems = []
@@ -49,6 +53,12 @@ if __name__ == "__main__":
         cpus.append(float(cpu_pct_avg))
         result['memory'].append(mem[1:-1])
         mems.append(float(mem_pct))
+    
+
+    for pod_abs_vals in pod_abs_out.split("\n"):
+        pod_cpu, pod_mem = pod_abs_vals.split(' ')
+        result['pod_cpu'].append(pod_cpu)
+        result['pod_mem'].append(pod_mem)
     
     # Prevent div-0 in the case of single-node.
     if counter != 0:

--- a/scripts/metrics/get_pod_stats_abs.sh
+++ b/scripts/metrics/get_pod_stats_abs.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+#* Result line i: <CPU of container user-container i> <Memory of container user-container i>
+kubectl top pod --containers | grep user-container | awk '{print $3,$4}'


### PR DESCRIPTION
Signed-off-by: Dohyun Park <dohyun1357@gmail.com>

## Summary
Change cluster metrics format to json because `gocsv` doesn't support `[]string`

Add pod metrics
- Use `kubectl top pod --containers | grep user-container` to find `user-container` cpu and memory usage
```
POD                                                               NAME             CPU(cores)   MEMORY(bytes)   
trace-func-0-11778647689845619749-00001-deployment-75fcb97gdh7n   user-container   15m          4Mi             
trace-func-0-41874010501951381-00001-deployment-57b4588bc7fnp5l   user-container   0m           5Mi             
trace-func-0-6943851027437367078-00001-deployment-6bc4977fdcq45   user-container   0m           7Mi  
```

resulting output is as such
```json
{"timestamp":1672972870502703,"master_cpu_pct":5,"master_mem_pct":6,"cpu":["243640202n","246013728n"],"cpu_pct_avg":2,"cpu_pct_max":2,"cpu_pct_active_avg":0,"memory":["2047732Ki","1549432Ki"],"memory_pct":0,"pod_cpu":["14m"],"pod_mem":["6Mi"]}
{"timestamp":1672972885521782,"master_cpu_pct":5,"master_mem_pct":6,"cpu":["242650215n","196935918n"],"cpu_pct_avg":1.5,"cpu_pct_max":2,"cpu_pct_active_avg":0,"memory":["2049924Ki","1549876Ki"],"memory_pct":0,"pod_cpu":["7m"],"pod_mem":["6Mi"]}
{"timestamp":1672972900513941,"master_cpu_pct":5,"master_mem_pct":6,"cpu":["235226172n","227049080n"],"cpu_pct_avg":2,"cpu_pct_max":2,"cpu_pct_active_avg":0,"memory":["2047716Ki","1549272Ki"],"memory_pct":0,"pod_cpu":["7m"],"pod_mem":["6Mi"]}

```

## Implementation Notes :hammer_and_pick:

* Current implementation is in line with previous metric scrapping.

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* Format change in `cluster_metrics` may cause issues with parsing

*Simply specify none (N/A) if not applicable.*
