### PR TITLE
fix prometheus chart version

### DIFF
--- a/scripts/setup/expose_infra_metrics.sh
+++ b/scripts/setup/expose_infra_metrics.sh
@@ -20,7 +20,8 @@ server_exec() {
 
 	server_exec 'kubectl create namespace monitoring'
 	release_label="prometheus"
-	server_exec "cd loader; helm install -n monitoring $release_label prometheus-community/kube-prometheus-stack -f config/prometh_stack_values.yaml"
+	prometheus_chart_version="43.3.1"
+	server_exec "cd loader; helm install -n monitoring $release_label --version $prometheus_chart_version prometheus-community/kube-prometheus-stack -f config/prometh_stack_values.yaml"
 	#* Apply the ServiceMonitors/PodMonitors to collect metrics from Knative.
 	#* The ports of the control manager and scheduler are mapped in a way that prometheus default installation can find them. 
 	server_exec 'cd loader; kubectl apply -f config/prometh_kn.yaml'


### PR DESCRIPTION
Signed-off-by: Dohyun Park <dohyun1357@gmail.com>

## Summary

Fix prometheus helm chart version to 43.3.1

We need to change the values to match the version when we later upgrade the Prometheus helm chart version.

## Implementation Notes :hammer_and_pick:

Added `--version` flag

## External Dependencies :four_leaf_clover:

* 

## Breaking API Changes :warning:

* 

*Simply specify none (N/A) if not applicable.*
