### PR TITLE
Change experiment driver to read from directory for function counts

### DIFF
--- a/tools/driver/experiment_driver_test.go
+++ b/tools/driver/experiment_driver_test.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"encoding/csv"
-	"github.com/sfreiberg/simplessh"
-	log "github.com/sirupsen/logrus"
 	"os"
 	"reflect"
 	"strconv"
 	"sync"
 	"testing"
+
+	"github.com/sfreiberg/simplessh"
+	log "github.com/sirupsen/logrus"
 )
 
 var loaderCfg = loaderConfig{
@@ -24,10 +25,11 @@ var loaderCfg = loaderConfig{
 		ExperimentDuration: 2,
 		WarmupDuration:     10,
 
-		IsPartiallyPanic:       false,
-		EnableZipkinTracing:    false,
-		EnableMetricsScrapping: false,
-		AutoscalingMetric:      "concurrency",
+		IsPartiallyPanic:            false,
+		EnableZipkinTracing:         false,
+		AutoscalingMetric:           "concurrency",
+		EnableMetricsScrapping:      false,
+		MetricScrapingPeriodSeconds: 60,
 
 		GRPCConnectionTimeoutSeconds: 60,
 		GRPCFunctionTimeoutSeconds:   900,

--- a/tools/driver/loaderConfig_1.json
+++ b/tools/driver/loaderConfig_1.json
@@ -10,8 +10,8 @@
  "IsPartiallyPanic": false,
  "EnableZipkinTracing": false,
  "EnableMetricsScrapping": false,
- "MetricScrapingPeriodSeconds": 0,
  "AutoscalingMetric": "concurrency",
+ "MetricScrapingPeriodSeconds": 60,
  "GRPCConnectionTimeoutSeconds": 60,
  "GRPCFunctionTimeoutSeconds": 900
 }

--- a/tools/driver/testDriverConfig.json
+++ b/tools/driver/testDriverConfig.json
@@ -20,5 +20,6 @@
   "EnableZipkinTracing":    false,
   "EnableMetricsScrapping": false,
   "AutoscalingMetric": "concurrency",
+  "MetricScrapingPeriodSeconds": 60,
   "separateIATGeneration": false
 }


### PR DESCRIPTION
## Summary

Instead of having the function count of a trace sample in the file name this changes it so it is read from the directory.
This is the same as the samples directory structure from the sampler, so it makes it easier to use. (No need to rename sample file names)

## Implementation Notes :hammer_and_pick:

* Briefly outline the overall technical solution. If necessary, identify talking points where the reviewer's attention should be drawn to.

## External Dependencies :four_leaf_clover:

* 

## Breaking API Changes :warning:

* 

*Simply specify none (N/A) if not applicable.*
