### PR TITLE
Use nodeSelector instead of taint

### DIFF
--- a/config/prometh_stack_values.yaml
+++ b/config/prometh_stack_values.yaml
@@ -530,7 +530,8 @@ alertmanager:
     ## Define which Nodes the Pods are scheduled on.
     ## ref: https://kubernetes.io/docs/user-guide/node-selection/
     ##
-    nodeSelector: {}
+    nodeSelector:
+      loader-nodetype: monitoring
 
     ## Define resources requests and limits for single Pods.
     ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
@@ -649,6 +650,8 @@ alertmanager:
 ##
 grafana:
   enabled: true
+  nodeSelector:
+    loader-nodetype: monitoring
   namespaceOverride: ""
 
   ## ForceDeployDatasources Create datasource configmap even if grafana deployment has been disabled
@@ -1346,6 +1349,8 @@ kubeStateMetrics:
 ## Configuration for kube-state-metrics subchart
 ##
 kube-state-metrics:
+  nodeSelector:
+    loader-nodetype: monitoring
   metricLabelsAllowlist:
     - pods=[*]
     - deployments=[app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/instance]
@@ -1500,7 +1505,8 @@ prometheusOperator:
       ##
       priorityClassName: ""
       podAnnotations: {}
-      nodeSelector: {}
+      nodeSelector:
+        loader-nodetype: monitoring
       affinity: {}
       tolerations: []
 
@@ -1667,8 +1673,8 @@ prometheusOperator:
   ## Define which Nodes the Pods are scheduled on.
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
-  nodeSelector: {}
-
+  nodeSelector:
+    loader-nodetype: monitoring
   ## Tolerations for use with node taints
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
@@ -2238,7 +2244,8 @@ prometheus:
     ## Define which Nodes the Pods are scheduled on.
     ## ref: https://kubernetes.io/docs/user-guide/node-selection/
     ##
-    nodeSelector: {}
+    nodeSelector:
+      loader-nodetype: monitoring
 
     ## Secrets is a list of Secrets in the same namespace as the Prometheus object, which shall be mounted into the Prometheus Pods.
     ## The Secrets are mounted into /etc/prometheus/secrets/. Secrets changes after initial creation of a Prometheus object are not

--- a/scripts/setup/expose_infra_metrics.sh
+++ b/scripts/setup/expose_infra_metrics.sh
@@ -43,6 +43,7 @@ server_exec() {
 	server_exec "sudo kubectl -n monitoring patch ServiceMonitor prometheus-prometheus-node-exporter --type json -p '[{"op": "add", "path": "/spec/endpoints/0/interval", "value": "15s"}]'"
 
 	sleep 5
+
 	#* Set up port prometheus panel (infinite loops are important to circumvent kubectl timeout in the middle of experiments).
 	server_exec 'tmux new -s prometheusd -d'
 	server_exec 'tmux send -t prometheusd "while true; do kubectl port-forward -n monitoring svc/prometheus-operated 9090; done" ENTER'

--- a/workloads/container/trace_func_go.yaml
+++ b/workloads/container/trace_func_go.yaml
@@ -19,6 +19,8 @@ spec:
         autoscaling.knative.dev/target: $AUTOSCALING_TARGET
     spec:
       containerConcurrency: 1
+      nodeSelector:
+        loader-nodetype: worker
       containers:
         - image: docker.io/cvetkovic/trace_function:latest
           # imagePullPolicy: Always  # No need if the tag is `latest`.


### PR DESCRIPTION
Signed-off-by: Dohyun Park <dohyun1357@gmail.com>

## Summary

Instead of using taints to isolate monitoring components, use nodeSelector and labels to fix pods to certain nodes.
This allows autoscaling of monitoring + control plane components while keeping workers isolated to worker nodes.
Fixes issue https://github.com/eth-easl/loader/issues/117

Tested with multi node clusters on cloudlab 

## Implementation Notes :hammer_and_pick:

* Briefly outline the overall technical solution. If necessary, identify talking points where the reviewer's attention should be drawn to.

## External Dependencies :four_leaf_clover:

* 

## Breaking API Changes :warning:

* 

*Simply specify none (N/A) if not applicable.*
