### PR TITLE
Add option for unlimited pod configuration

### DIFF
--- a/.github/configs/wordlist.txt
+++ b/.github/configs/wordlist.txt
@@ -138,6 +138,7 @@ Containerd
 containerPort
 coolDownTime
 Costa
+CPULimit
 CPUs
 cpu
 CRC
@@ -632,6 +633,7 @@ ustiugov
 Ustiugov
 utils
 UUID
+vCPU
 vhive
 vHive
 vHive's

--- a/cmd/config.json
+++ b/cmd/config.json
@@ -9,6 +9,7 @@
   "Granularity": "minute",
   "OutputPathPrefix": "data/out/experiment",
   "IATDistribution": "equidistant",
+  "CPULimit": "1vCPU",
   "ExperimentDuration": 5,
   "WarmupDuration": 0,
 

--- a/cmd/config_dirigent.json
+++ b/cmd/config_dirigent.json
@@ -8,6 +8,7 @@
   "Granularity": "minute",
   "OutputPathPrefix": "data/out/experiment",
   "IATDistribution": "equidistant",
+  "CPULimit": "1vCPU",
   "ExperimentDuration": 5,
   "WarmupDuration": 0,
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,23 +1,24 @@
 # Loader configuration file format
 
-| Parameter name               | Data type | Possible values                                                     | Default value       | Description                                                                     |
-|------------------------------|-----------|---------------------------------------------------------------------|---------------------|---------------------------------------------------------------------------------|
-| Seed                         | int64     | any                                                                 | 42                  | Seed for specification generator (for reproducibility)                          |
-| Platform                     | string    | Knative, OpenWhisk, AWSLambda                                       | Knative             | The serverless platform the functions will be executed on                       |
-| YAMLSelector                 | string    | wimpy, container, firecracker                                       | container           | Service YAML depending on sandbox type                                          |
-| EndpointPort                 | int       | > 0                                                                 | 80                  | Port to be appended to the service URL                                          |
-| TracePath                    | string    | string                                                              | data/traces         | Folder with Azure trace dimensions (invocations.csv, durations.csv, memory.csv) |
-| Granularity                  | string    | minute, second                                                      | minute              | Granularity for trace interpretation[^1]                                        |
-| OutputPathPrefix             | string    | any                                                                 | data/out/experiment | Results file(s) output path prefix                                              |
-| IATDistribution              | string    | exponential, exponential_shift, uniform, uniform_shift, equidistant | exponential         | IAT distribution[^2]                                                            |
-| ExperimentDuration           | int       | > 0                                                                 | 1                   | Experiment duration in minutes of trace to execute excluding warmup             |
-| WarmupDuration               | int       | > 0                                                                 | 0                   | Warmup duration in minutes(disabled if zero)                                    |
-| IsPartiallyPanic             | bool      | true/false                                                          | false               | Pseudo-panic-mode only in Knative                                               |
-| EnableZipkinTracing          | bool      | true/false                                                          | false               | Show loader span in Zipkin traces                                               |
-| EnableMetricsScrapping       | bool      | true/false                                                          | false               | Scrap cluster-wide metrics                                                      |
-| MetricScrapingPeriodSeconds  | int       | > 0                                                                 | 15                  | Period of Prometheus metrics scrapping                                          |
-| GRPCConnectionTimeoutSeconds | int       | > 0                                                                 | 60                  | Timeout for establishing a gRPC connection                                      |
-| GRPCFunctionTimeoutSeconds   | int       | > 0                                                                 | 90                  | Maximum time given to function to execute[^3]                                   |
+| Parameter name               | Data type | Possible values                                                     | Default value       | Description                                                                          |
+|------------------------------|-----------|---------------------------------------------------------------------|---------------------|--------------------------------------------------------------------------------------|
+| Seed                         | int64     | any                                                                 | 42                  | Seed for specification generator (for reproducibility)                               |
+| Platform                     | string    | Knative, OpenWhisk, AWSLambda                                       | Knative             | The serverless platform the functions will be executed on                            |
+| YAMLSelector                 | string    | wimpy, container, firecracker                                       | container           | Service YAML depending on sandbox type                                               |
+| EndpointPort                 | int       | > 0                                                                 | 80                  | Port to be appended to the service URL                                               |
+| TracePath                    | string    | string                                                              | data/traces         | Folder with Azure trace dimensions (invocations.csv, durations.csv, memory.csv)      |
+| Granularity                  | string    | minute, second                                                      | minute              | Granularity for trace interpretation[^1]                                             |
+| OutputPathPrefix             | string    | any                                                                 | data/out/experiment | Results file(s) output path prefix                                                   |
+| IATDistribution              | string    | exponential, exponential_shift, uniform, uniform_shift, equidistant | exponential         | IAT distribution[^2]                                                                 |
+| CPULimit                     | string    | 1vCPU, GCP                                                          | 1vCPU               | Imposed CPU limits on worker containers (only applicable for 'Knative' platform)[^3] |
+| ExperimentDuration           | int       | > 0                                                                 | 1                   | Experiment duration in minutes of trace to execute excluding warmup                  |
+| WarmupDuration               | int       | > 0                                                                 | 0                   | Warmup duration in minutes(disabled if zero)                                         |
+| IsPartiallyPanic             | bool      | true/false                                                          | false               | Pseudo-panic-mode only in Knative                                                    |
+| EnableZipkinTracing          | bool      | true/false                                                          | false               | Show loader span in Zipkin traces                                                    |
+| EnableMetricsScrapping       | bool      | true/false                                                          | false               | Scrap cluster-wide metrics                                                           |
+| MetricScrapingPeriodSeconds  | int       | > 0                                                                 | 15                  | Period of Prometheus metrics scrapping                                               |
+| GRPCConnectionTimeoutSeconds | int       | > 0                                                                 | 60                  | Timeout for establishing a gRPC connection                                           |
+| GRPCFunctionTimeoutSeconds   | int       | > 0                                                                 | 90                  | Maximum time given to function to execute[^4]                                        |
 
 [^1]: The second granularity feature interprets each column of the trace as a second, rather than as a minute, and
 generates IAT for each second. This feature is useful for fine-grained and precise invocation scheduling in experiments
@@ -25,5 +26,7 @@ involving stable low load.
 
 [^2]: `_shift` modifies the IAT generation in the following way: by default, generation will create first invocation in the beginning of the minute, with `_shift` modifier, it will be shifted inside the minute to remove the burst of invocations from all the functions.
 
-[^3]: Function can execute for at most 15 minutes as in AWS
+[^3]: Limits are set by resource->limits->CPU in the service YAML. `1vCPU` means limit of 1CPU is set, at the same time execution is also limited by the container concurrency limit of 1. `GCP` means limits are set to multiples of 1/12th of vCPU, based on the memory consumption of the function according to this [table](https://cloud.google.com/functions/pricing#compute_time) for Google Cloud Functions.
+
+[^4]: Function can execute for at most 15 minutes as in AWS
 Lambda; https://aws.amazon.com/about-aws/whats-new/2018/10/aws-lambda-supports-functions-that-can-run-up-to-15-minutes/

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -43,6 +43,7 @@ type LoaderConfiguration struct {
 	Granularity        string `json:"Granularity"`
 	OutputPathPrefix   string `json:"OutputPathPrefix"`
 	IATDistribution    string `json:"IATDistribution"`
+	CPULimit           string `json:"CPULimit"`
 	ExperimentDuration int    `json:"ExperimentDuration"`
 	WarmupDuration     int    `json:"WarmupDuration"`
 

--- a/pkg/config/parser_test.go
+++ b/pkg/config/parser_test.go
@@ -52,6 +52,7 @@ func TestConfigParser(t *testing.T) {
 		config.Granularity != "minute" ||
 		!strings.HasPrefix(config.OutputPathPrefix, "data/out/experiment") ||
 		config.IATDistribution != "equidistant" ||
+		config.CPULimit != "1vCPU" ||
 		config.ExperimentDuration != 5 ||
 		config.WarmupDuration != 0 ||
 		config.IsPartiallyPanic != false ||

--- a/pkg/config/test_config.json
+++ b/pkg/config/test_config.json
@@ -9,6 +9,7 @@
   "Granularity": "minute",
   "OutputPathPrefix": "data/out/experiment",
   "IATDistribution": "equidistant",
+  "CPULimit": "1vCPU",
   "ExperimentDuration": 5,
   "WarmupDuration": 0,
 

--- a/pkg/driver/trace_driver.go
+++ b/pkg/driver/trace_driver.go
@@ -641,7 +641,7 @@ func (d *Driver) RunExperiment(iatOnly bool, generated bool) {
 		trace.DoStaticTraceProfiling(d.Configuration.Functions)
 	}
 
-	trace.ApplyResourceLimits(d.Configuration.Functions)
+	trace.ApplyResourceLimits(d.Configuration.Functions, d.Configuration.LoaderConfiguration.CPULimit)
 
 	switch d.Configuration.LoaderConfiguration.Platform {
 	case "Knative":

--- a/pkg/trace/profiler.go
+++ b/pkg/trace/profiler.go
@@ -25,9 +25,10 @@
 package trace
 
 import (
+	"math"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/vhive-serverless/loader/pkg/common"
-	"math"
 )
 
 func DoStaticTraceProfiling(functions []*common.Function) {
@@ -39,10 +40,16 @@ func DoStaticTraceProfiling(functions []*common.Function) {
 	}
 }
 
-func ApplyResourceLimits(functions []*common.Function) {
+func ApplyResourceLimits(functions []*common.Function, CPULimit string) {
 	for i := 0; i < len(functions); i++ {
 		memoryPct100 := int(functions[i].MemoryStats.Percentile100)
-		cpuShare := ConvertMemoryToCpu(memoryPct100)
+		var cpuShare int
+		switch CPULimit {
+		case "1vCPU":
+			cpuShare = 1000
+		case "GCP":
+			cpuShare = ConvertMemoryToCpu(memoryPct100)
+		}
 
 		functions[i].CPURequestsMilli = cpuShare / common.OvercommitmentRatio
 		functions[i].MemoryRequestsMiB = memoryPct100 / common.OvercommitmentRatio

--- a/pkg/trace/profiler_test.go
+++ b/pkg/trace/profiler_test.go
@@ -25,13 +25,15 @@
 package trace
 
 import (
-	"github.com/vhive-serverless/loader/pkg/common"
 	"testing"
+
+	"github.com/vhive-serverless/loader/pkg/common"
 )
 
 func TestStaticTraceProfiling(t *testing.T) {
 	tests := []struct {
 		testName             string
+		CPULimit             string
 		IPM                  int
 		memoryMaxPercentile  float64
 		expectedInitialScale int
@@ -39,6 +41,7 @@ func TestStaticTraceProfiling(t *testing.T) {
 	}{
 		{
 			testName:             "concurrency_30ipm",
+			CPULimit:             "GCP",
 			IPM:                  30,
 			memoryMaxPercentile:  256,
 			expectedInitialScale: 1,
@@ -46,6 +49,7 @@ func TestStaticTraceProfiling(t *testing.T) {
 		},
 		{
 			testName:             "concurrency_45ipm",
+			CPULimit:             "GCP",
 			IPM:                  45,
 			memoryMaxPercentile:  512,
 			expectedInitialScale: 2,
@@ -53,6 +57,7 @@ func TestStaticTraceProfiling(t *testing.T) {
 		},
 		{
 			testName:             "concurrency_60ipm",
+			CPULimit:             "GCP",
 			IPM:                  60,
 			memoryMaxPercentile:  1024,
 			expectedInitialScale: 2,
@@ -60,9 +65,18 @@ func TestStaticTraceProfiling(t *testing.T) {
 		},
 		{
 			testName:             "concurrency_120ipm",
+			CPULimit:             "GCP",
 			IPM:                  120,
 			memoryMaxPercentile:  2048,
 			expectedInitialScale: 4,
+			expectedCPULimits:    1000,
+		},
+		{
+			testName:             "concurrency_120ipm_1vCPU",
+			CPULimit:             "1vCPU",
+			IPM:                  30,
+			memoryMaxPercentile:  256,
+			expectedInitialScale: 1,
 			expectedCPULimits:    1000,
 		},
 	}
@@ -82,7 +96,7 @@ func TestStaticTraceProfiling(t *testing.T) {
 			}
 
 			DoStaticTraceProfiling([]*common.Function{f})
-			ApplyResourceLimits([]*common.Function{f})
+			ApplyResourceLimits([]*common.Function{f}, test.CPULimit)
 
 			if f.InitialScale != test.expectedInitialScale ||
 				f.CPULimitsMilli != test.expectedCPULimits ||


### PR DESCRIPTION
Signed-off-by: Leonid Kondrashov <leo.kondrashov@gmail.com>

## Summary

Add option for unlimited pods in driver configuration. Now unlimited pods may be enabled by `"container_unlimited"` as `"YAMLSelector"` in `driverConfig.json`. Resolves #139.

## Implementation Notes :hammer_and_pick:

Add new .yaml file with limits disabled, add a case in switch inside loader to pick necessary file.

## External Dependencies :four_leaf_clover:

N/A

## Breaking API Changes :warning:

N/A
