### PR TITLE
Moved init-scale patch to main script

### DIFF
--- a/scripts/setup/create_multinode.sh
+++ b/scripts/setup/create_multinode.sh
@@ -234,6 +234,8 @@ function clone_loader_on_workers() {
     copy_k8s_certificates "$@"
     clone_loader_on_workers "$@"
 
+    server_exec $MASTER_NODE 'cd loader; bash scripts/setup/patch_init_scale.sh'
+
     if [[ "$DEPLOY_PROMETHEUS" == true ]]; then
         source $DIR/taint.sh
 

--- a/scripts/setup/expose_infra_metrics.sh
+++ b/scripts/setup/expose_infra_metrics.sh
@@ -53,6 +53,5 @@ server_exec() {
 
 	echo 'Done setting up monitoring components'
 
-	server_exec 'cd loader; bash scripts/setup/patch_init_scale.sh'
 	exit
 }


### PR DESCRIPTION
Making Prometheus deployment optional made the important script not execute. This fix sets `initial-scale` to 0 on function deployment.