### PR TITLE
Fix granularity passing through experiment driver

### DIFF
--- a/tools/driver/driverConfig.json
+++ b/tools/driver/driverConfig.json
@@ -21,5 +21,6 @@
   "EnableMetricsScrapping": false,
   "AutoscalingMetric": "concurrency",
   "MetricScrapingPeriodSeconds": 60,
-  "separateIATGeneration": false
+  "separateIATGeneration": false,
+  "Granularity": "minute"
 }

--- a/tools/driver/experiment_driver.go
+++ b/tools/driver/experiment_driver.go
@@ -23,6 +23,7 @@ type LoaderConfiguration struct {
 	EndpointPort int    `json:"EndpointPort"`
 
 	TracePath          string `json:"TracePath"`
+	Granularity        string `json:"Granularity"`
 	OutputPathPrefix   string `json:"OutputPathPrefix"`
 	IATDistribution    string `json:"IATDistribution"`
 	ExperimentDuration int    `json:"ExperimentDuration"`
@@ -67,6 +68,7 @@ type Driver struct {
 	MetricScrapingPeriodSeconds int    `json:"MetricScrapingPeriodSeconds"`
 	SeparateIATGeneration       bool   `json:"separateIATGeneration"`
 	AutoscalingMetric           string `json:"AutoscalingMetric"`
+	Granularity                 string `json:"Granularity"`
 	loaderConfig                loaderConfig
 }
 
@@ -156,6 +158,7 @@ func (d *Driver) createLoaderConfig(functionNumber int) loaderConfig {
 		EndpointPort: 80,
 
 		TracePath:          loaderTracePath,
+		Granularity:        d.Granularity,
 		OutputPathPrefix:   d.LoaderOutputPath,
 		IATDistribution:    d.IATDistribution,
 		ExperimentDuration: d.ExperimentDuration,

--- a/tools/driver/loaderConfig_1.json
+++ b/tools/driver/loaderConfig_1.json
@@ -3,6 +3,7 @@
  "YAMLSelector": "container",
  "EndpointPort": 80,
  "TracePath": "data/traces",
+ "Granularity": "minute",
  "OutputPathPrefix": "data/out/experiment",
  "IATDistribution": "exponential",
  "ExperimentDuration": 2,


### PR DESCRIPTION
## Summary

After introduction of different modes of loader interpretation of traces, driver was not updated. Fix experiment driver by passing the trace granularity from driver config to loader.

## Implementation Notes :hammer_and_pick:

* Simple pass through for configuration.

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A

*Simply specify none (N/A) if not applicable.*
