### PR TITLE
Fix cleanup with Prometheus disabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,9 @@ proto:
 # make -i clean
 clean: 
 # 	kubectl rollout restart deployment activator -n knative-serving
-	kubectl rollout restart statefulset prometheus-prometheus-kube-prometheus-prometheus -n monitoring
+
+	scripts/util/clean_prometheus.sh
+
 	kn service delete --all
 	kubectl delete --all all -n default --grace-period=0 
 

--- a/scripts/util/clean_prometheus.sh
+++ b/scripts/util/clean_prometheus.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+if [ `kubectl get statefulset -A | grep prometheus-prometheus-kube-prometheus-prometheus | wc -l` -ne "0" ]
+then
+	kubectl rollout restart statefulset prometheus-prometheus-kube-prometheus-prometheus -n monitoring
+fi


### PR DESCRIPTION
## Summary

After introduction of optional Prometheus deployment, `make clean` was broken for setups without Prometheus. Fixes #155.

## Implementation Notes :hammer_and_pick:

* Cleanup of Prometheus was moved to separate script which checks if Prometheus deployed before resetting it.

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A

*Simply specify none (N/A) if not applicable.*
