### PR TITLE
Rework failed invocations monitoring

### DIFF
--- a/pkg/driver/trace_driver_test.go
+++ b/pkg/driver/trace_driver_test.go
@@ -89,12 +89,12 @@ func TestInvokeFunctionFromDriver(t *testing.T) {
 		t.Run(test.testName, func(t *testing.T) {
 			var successCount int64 = 0
 			var failureCount int64 = 0
-			var approximateFailureCount int64 = 0
 
 			invocationRecordOutputChannel := make(chan *metric.ExecutionRecord, 1)
 			announceDone := &sync.WaitGroup{}
 
 			testDriver := createTestDriver()
+			var failureCountByMinute = make([]int64, testDriver.Configuration.TraceDuration)
 
 			if !test.forceFail {
 				address, port := "localhost", test.port
@@ -113,11 +113,11 @@ func TestInvokeFunctionFromDriver(t *testing.T) {
 					Memory:  128,
 				},
 				Phase:                  common.ExecutionPhase,
-				MinuteIndex:            1,
+				MinuteIndex:            0,
 				InvocationIndex:        2,
 				SuccessCount:           &successCount,
 				FailedCount:            &failureCount,
-				ApproximateFailedCount: &approximateFailureCount,
+				FailedCountByMinute:    failureCountByMinute,
 				RecordOutputChannel:    invocationRecordOutputChannel,
 				AnnounceDoneWG:         announceDone,
 			}
@@ -380,7 +380,7 @@ func TestProceedToNextMinute(t *testing.T) {
 	}{
 		{
 			testName:        "proceed_to_next_minute_no_break_no_fail",
-			minuteIndex:     2,
+			minuteIndex:     0,
 			invocationIndex: 95,
 			failedCount:     0,
 			skipMinute:      false,
@@ -388,7 +388,7 @@ func TestProceedToNextMinute(t *testing.T) {
 		},
 		{
 			testName:        "proceed_to_next_minute_break_no_fail",
-			minuteIndex:     3,
+			minuteIndex:     0,
 			invocationIndex: 75,
 			failedCount:     0,
 			skipMinute:      false,
@@ -396,7 +396,7 @@ func TestProceedToNextMinute(t *testing.T) {
 		},
 		{
 			testName:        "proceed_to_next_minute_break_with_fail",
-			minuteIndex:     3,
+			minuteIndex:     0,
 			invocationIndex: 90,
 			failedCount:     55,
 			skipMinute:      false,
@@ -412,17 +412,18 @@ func TestProceedToNextMinute(t *testing.T) {
 			invocationIndex := test.invocationIndex
 			startOfMinute := time.Now()
 			phase := common.ExecutionPhase
-			var approximateFailedCount = test.failedCount
+			var failedCountByMinute = make([]int64, driver.Configuration.TraceDuration)
+			failedCountByMinute[minuteIndex] = test.failedCount
 			var iatSum int64 = 2500
 
 			toBreak := driver.proceedToNextMinute(function, &minuteIndex, &invocationIndex, &startOfMinute,
-				test.skipMinute, &phase, &approximateFailedCount, &iatSum)
+				test.skipMinute, &phase, failedCountByMinute, &iatSum)
 
 			if toBreak != test.toBreak {
 				t.Error("Invalid response from minute cleanup procedure.")
 			}
 
-			if !toBreak && ((minuteIndex != test.minuteIndex+1) || (invocationIndex != 0) || (approximateFailedCount != 0) || (iatSum != 0)) {
+			if !toBreak && ((minuteIndex != test.minuteIndex+1) || (invocationIndex != 0) || (failedCountByMinute[test.minuteIndex] != 0) || (iatSum != 0)) {
 				t.Error("Invalid response from minute cleanup procedure.")
 			}
 		})


### PR DESCRIPTION
## Summary

Rework monitoring for failed invocations. Previously, only failures happened in the last minute were compared to number of invocations issued in the last minute. However, this comparison might be inconsistent: functions can fail during subsequent minutes instead of minute in which they were invoked. This issue represented intself as "Invalid arguments provided to runtime assertion." (#129), when number of failures exceeds number of invocations.

This PR will fix only the assert failure (fixes #129), not the underlying failures of invocations. 

## Implementation Notes :hammer_and_pick:

Instead of one variable for failure happened in the last minute, array of counters for each minute was used. Values in this array were compared to number of issued invocation in respective minute, monitoring real failure rate.

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A
