### PR TITLE
Add scraping for memory and CPU requests

### DIFF
--- a/pkg/metric/record.go
+++ b/pkg/metric/record.go
@@ -95,17 +95,27 @@ type KnStats struct {
 }
 
 type ClusterUsage struct {
-	Timestamp       int64    `csv:"timestamp" json:"timestamp"`
-	MasterCpuPct    float64  `csv:"master_cpu_pct" json:"master_cpu_pct"`
-	MasterMemoryPct float64  `csv:"master_mem_pct" json:"master_mem_pct"`
-	Cpu             []string `csv:"cpu" json:"cpu"`
-	CpuPctAvg       float64  `csv:"cpu_pct_avg" json:"cpu_pct_avg"`
-	CpuPctMax       float64  `csv:"cpu_pct_max" json:"cpu_pct_max"`
-	CpuPctActiveAvg float64  `csv:"cpu_pct_active_avg" json:"cpu_pct_active_avg"`
-	Memory          []string `csv:"memory" json:"memory"`
-	MemoryPctAvg    float64  `csv:"memory_pct" json:"memory_pct"`
-	PodCpu          []string `csv:"pod_cpu" json:"pod_cpu"`
-	PodMemory       []string `csv:"pod_memory" json:"pod_mem"`
+	Timestamp       int64     `csv:"timestamp" json:"timestamp"`
+	MasterCpuPct    float64   `csv:"master_cpu_pct" json:"master_cpu_pct"`
+	MasterCpuReq    float64   `csv:"master_cpu_req" json:"master_cpu_req"`
+	MasterCpuLim    float64   `csv:"master_cpu_lim" json:"master_cpu_lim"`
+	MasterMemoryPct float64   `csv:"master_mem_pct" json:"master_mem_pct"`
+	MasterMemoryReq float64   `csv:"master_mem_req" json:"master_mem_req"`
+	MasterMemoryLim float64   `csv:"master_mem_lim" json:"master_mem_lim"`
+	MasterPods      int       `csv:"master_pods" json:"master_pods"`
+	Cpu             []string  `csv:"cpu" json:"cpu"`
+	CpuReq          []float64 `csv:"cpu_req" json:"cpu_req"`
+	CpuLim          []float64 `csv:"cpu_lim" json:"cpu_lim"`
+	CpuPctAvg       float64   `csv:"cpu_pct_avg" json:"cpu_pct_avg"`
+	CpuPctMax       float64   `csv:"cpu_pct_max" json:"cpu_pct_max"`
+	CpuPctActiveAvg float64   `csv:"cpu_pct_active_avg" json:"cpu_pct_active_avg"`
+	Memory          []string  `csv:"memory" json:"memory"`
+	MemoryReq       []float64 `csv:"memory_req" json:"memory_req"`
+	MemoryLim       []float64 `csv:"memory_lim" json:"memory_lim"`
+	MemoryPctAvg    float64   `csv:"memory_pct" json:"memory_pct"`
+	PodCpu          []string  `csv:"pod_cpu" json:"pod_cpu"`
+	PodMemory       []string  `csv:"pod_memory" json:"pod_mem"`
+	Pods            []int     `csv:"pods" json:"pods"`
 }
 
 type AdfResult struct {

--- a/pkg/metric/scrape_infra.py
+++ b/pkg/metric/scrape_infra.py
@@ -1,26 +1,47 @@
 import subprocess
 import json
 import sys
+import os
 
 loader_total_cores = 8
+
+def get_promql_query(query):
+    def promql_query():
+        return "tools/bin/promql --no-headers --host 'http://localhost:9090' '" + query + "' | awk '{print $2}'"
+    return promql_query
 
 if __name__ == "__main__":
     cmd_get_loader_pct = ['bash', 'scripts/metrics/get_loader_cpu_pct.sh']
     cmd_get_abs_vals = ['bash', 'scripts/metrics/get_node_stats_abs.sh']
     cmd_get_pcts = ['bash', 'scripts/metrics/get_node_stats_percent.sh']
     cmd_get_pod_abs_vals = ['bash', 'scripts/metrics/get_pod_stats_abs.sh']
+    query_mem_req = 'sum(kube_pod_container_resource_requests{resource="memory"} and on(container, pod) (kube_pod_container_status_running==1)) by (node)'
+    query_mem_lim = 'sum(kube_pod_container_resource_limits{resource="memory"} and on(container, pod) (kube_pod_container_status_running==1)) by (node)'
+    query_cpu_req = 'sum(kube_pod_container_resource_requests{resource="cpu"} and on(container, pod) (kube_pod_container_status_running==1)) by (node)'
+    query_cpu_lim = 'sum(kube_pod_container_resource_limits{resource="cpu"} and on(container, pod) (kube_pod_container_status_running==1)) by (node)'
+    query_pod_count = 'count(kube_pod_info and on(pod) max(kube_pod_container_status_running==1) by (pod)) by(node)'
 
     result = {
         "master_cpu_pct": 0,
+        "master_cpu_req": 0,
+        "master_cpu_lim": 0,
         "master_mem_pct": 0,
+        "master_mem_req": 0,
+        "master_mem_lim": 0,
+        "master_pods": 0,
         "cpu": [],
+        "cpu_req": [],
+        "cpu_lim": [],
         "cpu_pct_avg": 0,
         "cpu_pct_active_avg": 0,
         "cpu_pct_max": 0,
         "memory": [],
+        "memory_req": [],
+        "memory_lim": [],
         "memory_pct": 0,
         "pod_cpu": [],
         "pod_mem": [],
+        "pods": [],
     }
 
     loader_cpu_pct, loader_mem_pct = list(
@@ -28,20 +49,30 @@ if __name__ == "__main__":
     )
     loader_cpu_pct /= loader_total_cores #* Normalise to [0, 100]
 
-    abs_out = subprocess.check_output(cmd_get_abs_vals).decode("utf-8")[:-1]
-    pcts_out = subprocess.check_output(cmd_get_pcts).decode("utf-8")
-    pod_abs_out = subprocess.check_output(cmd_get_pod_abs_vals).decode("utf-8")[:-1]
+    abs_out = subprocess.check_output(cmd_get_abs_vals).decode("utf-8")[:-1].split('\n')
+    pcts_out = subprocess.check_output(cmd_get_pcts).decode("utf-8").split('\n')
+    pod_abs_out = subprocess.check_output(cmd_get_pod_abs_vals).decode("utf-8")[:-1].split('\n')
+    mem_req = os.popen(get_promql_query(query_mem_req)()).read().strip().split('\n')
+    mem_lim = os.popen(get_promql_query(query_mem_lim)()).read().strip().split('\n')
+    cpu_req = os.popen(get_promql_query(query_cpu_req)()).read().strip().split('\n')
+    cpu_lim = os.popen(get_promql_query(query_cpu_lim)()).read().strip().split('\n')
+    pod_count = os.popen(get_promql_query(query_pod_count)()).read().strip().split('\n')
 
     cpus = []
     mems = []
     counter = 0
     is_master = True
-    for abs_vals, pcts in zip(abs_out.split('\n'), pcts_out.split('\n')):
+    for abs_vals, pcts, mem_r, mem_l, cpu_r, cpu_l, pod in zip(abs_out, pcts_out, mem_req, mem_lim, cpu_req, cpu_lim, pod_count):
         if is_master:
             # Record master node.
             result['master_cpu_pct'], result['master_mem_pct'] = list(map(float, pcts[:-1].split('%')))
             result['master_cpu_pct'] = max(0, result['master_cpu_pct'] - loader_cpu_pct)
             result['master_mem_pct'] = max(0, result['master_mem_pct'] - loader_mem_pct)
+            result['master_mem_req'] = float(mem_r)
+            result['master_mem_lim'] = float(mem_l)
+            result['master_cpu_req'] = float(cpu_r)
+            result['master_cpu_lim'] = float(cpu_l)
+            result['master_pods'] = int(pod)
             is_master = False
             continue
 
@@ -53,9 +84,14 @@ if __name__ == "__main__":
         cpus.append(float(cpu_pct_avg))
         result['memory'].append(mem[1:-1])
         mems.append(float(mem_pct))
+        result['memory_req'].append(float(mem_r))
+        result['memory_lim'].append(float(mem_l))
+        result['cpu_req'].append(float(cpu_r))
+        result['cpu_lim'].append(float(cpu_l))
+        result['pods'].append(int(pod))
     
 
-    for pod_abs_vals in pod_abs_out.split("\n"):
+    for pod_abs_vals in pod_abs_out:
         pod_cpu, pod_mem = pod_abs_vals.split(' ')
         result['pod_cpu'].append(pod_cpu)
         result['pod_mem'].append(pod_mem)


### PR DESCRIPTION
## Summary

Add scraping of CPU and memory requests from nodes and placed pods on nodes in k8s cluster. These numbers should be representative of what is used by cluster scheduler during pod placement.

## Implementation Notes :hammer_and_pick:

* Retrieves values for CPU and memory requests and pod counts on nodes with use of Prometheus queries during infrastructure metric scraping.

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A
