### PR TITLE
Fix scraping of requested resources

### DIFF
--- a/pkg/metric/scrape_infra.py
+++ b/pkg/metric/scrape_infra.py
@@ -7,7 +7,7 @@ loader_total_cores = 8
 
 def get_promql_query(query):
     def promql_query():
-        return "tools/bin/promql --no-headers --host 'http://localhost:9090' '" + query + "' | awk '{print $2}'"
+        return "tools/bin/promql --no-headers --host 'http://localhost:9090' '" + query + "' | grep . | sort | awk '{print $2}'"
     return promql_query
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

#175 has a bug with dividing metrics between master node and worker nodes. Fix introduces a sorting for output of PromQL.

## Implementation Notes :hammer_and_pick:

* Scrape metric script depends on the ordering of data in arrays (first goes master, all other nodes after)
* PromQL does not sort output by labels, so it should be done by external commands (`grep` to remove empty line and `sort` to get correctly ordered data)
* `node-0` is considered master, which is consistent with other scraped metrics

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A
