### PR TITLE
Fix duration distribution

### DIFF
--- a/pkg/generator/specification.go
+++ b/pkg/generator/specification.go
@@ -1,9 +1,10 @@
 package generator
 
 import (
+	"math/rand"
+
 	"github.com/eth-easl/loader/pkg/common"
 	log "github.com/sirupsen/logrus"
-	"math/rand"
 )
 
 type SpecificationGenerator struct {
@@ -156,13 +157,10 @@ func (s *SpecificationGenerator) generateExecuteSpec(runQtl float64, runStats *c
 		runtime = s.randIntBetween(runStats.Percentile25, runStats.Percentile50)
 	case runQtl <= 0.75:
 		runtime = s.randIntBetween(runStats.Percentile50, runStats.Percentile75)
-	case runQtl <= 0.95:
-		runtime = s.randIntBetween(runStats.Percentile75, runStats.Percentile99)
 	case runQtl <= 0.99:
-		runtime = s.randIntBetween(runStats.Percentile99, runStats.Percentile100)
+		runtime = s.randIntBetween(runStats.Percentile75, runStats.Percentile99)
 	case runQtl < 1:
-		// NOTE: 100th percentile is smaller from the max. somehow.
-		runtime = int(runStats.Percentile100)
+		runtime = s.randIntBetween(runStats.Percentile99, runStats.Percentile100)
 	}
 
 	return runtime


### PR DESCRIPTION
## Summary

Fix of runtime specification generation. Previously, 100th percentile was used in 1% of cases (0.99 < runQtl < 1), essentially, interpreting it as 99th percentile. This might lead to load overestimation when replaying trace.

## Implementation Notes :hammer_and_pick:

* Change of limits in switch to corresponding one of precentiles.

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A
