### PR TITLE
Track gRPC connection establish time

### DIFF
--- a/pkg/driver/grpc_client.go
+++ b/pkg/driver/grpc_client.go
@@ -52,6 +52,8 @@ func Invoke(function *common.Function, runtimeSpec *common.RuntimeSpecification,
 		return false, record
 	}
 
+	record.GRPCConnectionEstablishTime = time.Since(start).Microseconds()
+
 	grpcClient := proto.NewExecutorClient(conn)
 
 	executionCxt, cancelExecution := context.WithTimeout(context.Background(), time.Duration(cfg.GRPCFunctionTimeoutSeconds)*time.Second)

--- a/pkg/metric/record.go
+++ b/pkg/metric/record.go
@@ -17,10 +17,11 @@ type ExecutionRecord struct {
 	StartTime    int64  `csv:"startTime"`
 
 	// Measurements in microseconds
-	RequestedDuration uint32 `csv:"requestedDuration"`
-	ResponseTime      int64  `csv:"responseTime"`
-	ActualDuration    uint32 `csv:"actualDuration"`
-	ActualMemoryUsage uint32 `csv:"actualMemoryUsage"`
+	RequestedDuration           uint32 `csv:"requestedDuration"`
+	GRPCConnectionEstablishTime int64  `csv:"grpcConnEstablish"`
+	ResponseTime                int64  `csv:"responseTime"`
+	ActualDuration              uint32 `csv:"actualDuration"`
+	ActualMemoryUsage           uint32 `csv:"actualMemoryUsage"`
 
 	MemoryAllocationTimeout bool `csv:"memoryAllocationTimeout"`
 	ConnectionTimeout       bool `csv:"connectionTimeout"`


### PR DESCRIPTION
gRPC connection should preferably be reused, whereas establishing a connection takes time. I propose this change to determine the contribution of connection establishment to the end-to-end latency of an invocation.