### PR TITLE
Fix intermittent problems with unready namespace during setup

### DIFF
--- a/scripts/setup/create_multinode.sh
+++ b/scripts/setup/create_multinode.sh
@@ -249,6 +249,13 @@ function clone_loader_on_workers() {
 
     # Notify the master that all nodes have joined the cluster
     server_exec $MASTER_NODE 'tmux send -t master "y" ENTER'
+
+    namespace_info=$(server_exec $MASTER_NODE "kubectl get namespaces")
+    while [[ ${namespace_info} != *'knative-serving'*  ]]; do
+        sleep 60
+        namespace_info=$(server_exec $MASTER_NODE "kubectl get namespaces")
+    done
+
     echo "Master node $MASTER_NODE finalised."
 
     # Copy API server certificates from master to each worker node


### PR DESCRIPTION
## Summary

Sometimes, during setup some errors were happening due to unready namespace `knative-serving` which led to issues with deployment on easystack VMs.

## Implementation Notes :hammer_and_pick:

* Add wait for namespace to be ready for next changes.

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A
