### PR TITLE
Add fake k8s nvidia plugin

### DIFF
--- a/config/nvidia-device-plugin.yml
+++ b/config/nvidia-device-plugin.yml
@@ -1,0 +1,62 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-device-plugin-daemonset
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: nvidia-device-plugin-ds
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      # This annotation is deprecated. Kept here for backward compatibility
+      # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        name: nvidia-device-plugin-ds
+    spec:
+      tolerations:
+      # This toleration is deprecated. Kept here for backward compatibility
+      # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      # Mark this pod as a critical add-on; when enabled, the critical add-on
+      # scheduler reserves resources for critical add-on pods so that they can
+      # be rescheduled after a failure.
+      # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+      priorityClassName: "system-node-critical"
+      containers:
+      - image: gaow0007/k8s-device-plugin:latest
+        name: nvidia-device-plugin-ctr
+        args: ["--fail-on-init-error=false", "-c=8"]
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+          - name: device-plugin
+            mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins

--- a/scripts/setup/create_multinode.sh
+++ b/scripts/setup/create_multinode.sh
@@ -275,4 +275,8 @@ function clone_loader_on_workers() {
     if [[ "$DEPLOY_PROMETHEUS" == true ]]; then
         $DIR/expose_infra_metrics.sh $MASTER_NODE
     fi
+
+    if [[ "$DEPLOY_GPU" == true ]]; then
+        $DIR/setup_nvidia_plugin.sh $MASTER_NODE
+    fi
 }

--- a/scripts/setup/setup.cfg
+++ b/scripts/setup/setup.cfg
@@ -4,3 +4,4 @@ CLUSTER_MODE='container' # choose from {container, firecracker, firecracker_snap
 PODS_PER_NODE=240
 GITHUB_TOKEN=$HOME/.git_token_loader
 DEPLOY_PROMETHEUS=false
+DEPLOY_GPU=false

--- a/scripts/setup/setup_nvidia_plugin.sh
+++ b/scripts/setup/setup_nvidia_plugin.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+MASTER_NODE=$1
+
+server_exec() { 
+	ssh -oStrictHostKeyChecking=no -p 22 $MASTER_NODE $1;
+}
+
+{
+	echo 'Setting up fake nvidia plugin'
+	rsync config/nvidia-device-plugin.yml $MASTER_NODE:~/nvidia-device-plugin.yml
+	
+	server_exec 'kubectl apply -f ~/nvidia-device-plugin.yml'
+
+	server_exec 'kubectl get pods -n kube-system'
+
+	echo 'Done setting up fake nvidia plugin'
+}


### PR DESCRIPTION
## Summary

Add one option to install a fake nvidia-plugin which emulates GPU resource allocation. 

## Implementation Notes :hammer_and_pick:

* Use the fake k8s-device-plugin  [container https://github.com/yzs981130/k8s-device-plugin/tree/fake_new ](https://github.com/eth-easl/loader/blob/gpu-support/config/nvidia-device-plugin.yml)
* After enable "DEPLOY_GPU" as true. Users would get   a new resource kind `nvidia.com/gpu` after running `kubectl describe nodes | grep nvidia ` on any deployed nodes. 

## External Dependencies :four_leaf_clover:

* The original implementation of fake k8s-device-plugin https://github.com/yzs981130/k8s-device-plugin/tree/fake_new

## Breaking API Changes :warning:

* 

*Simply specify none (N/A) if not applicable.*
