### PR TITLE
Fix: Resolved incorrect CLI argument type for tools/trace_synthesizer…

### DIFF
--- a/tools/trace_synthesizer/README.md
+++ b/tools/trace_synthesizer/README.md
@@ -12,7 +12,8 @@ Further the user can specify the execution time of the function(s), as well as t
 These are used to generate the memory and durations csv files. Like in the decommissioned RPS mode,
 the user can also specify the number of functions, which will simply be functions with different names,
 which then use different instances. All functions have the same execution time, memory footprint and RPS.  
-From within the trace_synthesizer folder, use:
+
+From within the `trace_synthesizer` folder, use:
 
 
 ```console
@@ -43,10 +44,9 @@ optional arguments:
 ```
 
 
-
 ### Example
 
 ```bash
-python3 trace_synthesizer generate -f 2 -b 10 -t 20 -s 5 -dur 3 -e 500 -m 350 -o example 
+python3 . generate -f 2 -b 10 -t 20 -s 5 -dur 3 -e 500 -mem 350 -o example -m 0
 ```
 

--- a/tools/trace_synthesizer/__main__.py
+++ b/tools/trace_synthesizer/__main__.py
@@ -117,6 +117,7 @@ def main():
         '-o',
         '--output',
         required=True,
+        type=str,
         metavar='path',
         help='Output path for the resulting trace'
     )
@@ -125,6 +126,7 @@ def main():
         '-m',
         '--mode',
         required=True,
+        type=int,
         metavar='integer',
         help='Normal [0]; RPS sweep [1]; Burst [2]'
     )


### PR DESCRIPTION
… & updated README.md

## Summary

Fixed a code bug where CLI argument for `mode` option is interpreted as a string instead of integer, resulting in inability to use the tool for `mode` equals to 0 or 1. 

## Implementation Notes :hammer_and_pick:

- Updated `__main__.py` in `tools/trace_synthesizer` by explicitly defining types for all CLI argument values
