### PR TITLE
Add check for failure in e2e test

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -61,6 +61,9 @@ jobs:
       - name: Build and run loader
         run: go run cmd/loader.go --config cmd/config.json
 
+      - name: Check the output
+        run: test $(grep true data/out/experiment_duration_2.csv | wc -l) -eq 0 # test the output file for errors (true means failure to invoke)
+
       - name: Print logs
         if: ${{ always() }}
         run: |


### PR DESCRIPTION
## Summary

Closes #248. Adds check for e2e test failures based on output file.

## Implementation Notes :hammer_and_pick:

* `grep`s output file for the presence of `true` values, which mean that there was a failure during invocation.

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A
