### PR TITLE
Filter out functions with 0 ms average execution time

### DIFF
--- a/sampler/preprocess.py
+++ b/sampler/preprocess.py
@@ -77,6 +77,8 @@ def transform_dfs(
 
     inv_df = remove_uninvoked(inv_df=inv_df)
 
+    run_df = remove_zero_duration(run_df=run_df)
+
     inv_df, mem_df, run_df = get_intersections(inv_df=inv_df, mem_df=mem_df, run_df=run_df)
 
     mem_df = build_mem_func_df(mem_df=mem_df, run_df=run_df)
@@ -113,6 +115,13 @@ def remove_uninvoked(inv_df: pd.DataFrame) -> pd.DataFrame:
 
     return inv_df_cleaned
 
+# Removes functions with an average execution time of 0 ms
+# Respective entries from memory and invocations dataframes will be filtered in get_instersection()
+def remove_zero_duration(run_df: pd.DataFrame) -> pd.DataFrame:
+    zero_duration = run_df.Average == 0
+    run_df_cleaned = run_df[~zero_duration]
+
+    return run_df_cleaned
 
 # Expands memory file with per-function memory usage (instead of the per-app as in the original trace)
 # Each function of an app uses proportional fraction of memory

--- a/sampler/tests/preprocess_test.py
+++ b/sampler/tests/preprocess_test.py
@@ -66,14 +66,15 @@ def test_input_cleaning():
     # - The function "fe" has duplicated contains a duplicate function
     # - The function "ff" (app "ad") is not in run df although "ad" app is in both dfs
     # - The function "fg" is not in run df
+    # - The function "fh" has an average execution time of 0 ms
     inv_df = pd.DataFrame(
         {
-            "HashApp": ["aa", "ab", "ac", "ad", "ad", "ad", "ad", "ae"],
-            "HashFunction": ["fa", "fb", "fc", "fd", "fe", "fe", "ff", "fg"],
-            "HashOwner": ["oa", "oa", "ob", "ob", "ob", "oc", "oc", "od"],
-            "Trigger": ["tr", "tr", "tr", "tr", "tr", "tr", "tr", "tr"],
-            "118": [0, 1, 2, 3, 4, 5, 6, 7],
-            "119": [0, 1, 2, 3, 4, 5, 6, 7],
+            "HashApp": ["aa", "ab", "ac", "ad", "ad", "ad", "ad", "ae", "af"],
+            "HashFunction": ["fa", "fb", "fc", "fd", "fe", "fe", "ff", "fg", "fh"],
+            "HashOwner": ["oa", "oa", "ob", "ob", "ob", "oc", "oc", "od", "oe"],
+            "Trigger": ["tr", "tr", "tr", "tr", "tr", "tr", "tr", "tr", "tr"],
+            "118": [0, 1, 2, 3, 4, 5, 6, 7, 8],
+            "119": [0, 1, 2, 3, 4, 5, 6, 7, 8],
         }
     )
 
@@ -115,17 +116,18 @@ def test_input_cleaning():
     )
 
     # Corruptions:
-    # - The last 2 rows have duplicate HashFunction
+    # - The HashFunction "fd" is duplicated
     # - Function "fa" is not in run df
     # - The app "ab" is not in mem df
+    # - The app "af" has an average execution time of 0 ms
     run_df = pd.DataFrame(
         {
-            "HashFunction": ["fa", "fb", "fe", "fd", "fd"],
-            "HashOwner": ["oa", "oa", "ob", "ob", "oc"],
-            "HashApp": ["aa", "ab", "ad", "ad", "ad"],
-            "Average": [10, 20, 30, 40, 50],
-            "Count": [1, 1, 1, 1, 1],
-            "Minimum": [4, 6, 8, 10, 12],
+            "HashFunction": ["fa", "fb", "fe", "fd", "fd", "fh"],
+            "HashOwner": ["oa", "oa", "ob", "ob", "oc", "oe"],
+            "HashApp": ["aa", "ab", "ad", "ad", "ad", "af"],
+            "Average": [10, 20, 30, 40, 50, 0],
+            "Count": [1, 1, 1, 1, 1, 1],
+            "Minimum": [4, 6, 8, 10, 12, 0],
         }
     )
 


### PR DESCRIPTION
## Summary

Closes #278 by filtering out functions with an average execution time of 0 ms during pre-processing.

## Implementation Notes :hammer_and_pick:

* Remove the rows from the run_df where the average is equal to 0, use get_intersections to remove those functions from the invocations and memory dataframes.

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A


