### PR TITLE
Move function images to Github Container Registry

### DIFF
--- a/Dockerfile.trace
+++ b/Dockerfile.trace
@@ -37,3 +37,5 @@ COPY --from=BUILDER /app/server/trace-func-go/server /server
 
 # Run the web service on container startup.
 CMD /server ${FUNC_PORT_ENV} ${FUNC_TYPE_ENV}
+
+LABEL org.opencontainers.image.source=https://github.com/vhive-serverless/invitro

--- a/Makefile
+++ b/Makefile
@@ -53,32 +53,32 @@ trace-firecracker:
 	docker build --build-arg FUNC_TYPE=TRACE \
 		--build-arg FUNC_PORT=50051 \
 		-f Dockerfile.trace \
-		-t cvetkovic/trace_function_firecracker .
-	docker push cvetkovic/trace_function_firecracker:latest
+		-t ghcr.io/vhive-serverless/invitro_trace_function_firecracker .
+	docker push ghcr.io/vhive-serverless/invitro_trace_function_firecracker:latest
 
 # Used for replying the trace
 trace-container:
 	docker build --build-arg FUNC_TYPE=TRACE \
 		--build-arg FUNC_PORT=80 \
 		-f Dockerfile.trace \
-		-t cvetkovic/trace_function .
-	docker push cvetkovic/trace_function:latest
+		-t ghcr.io/vhive-serverless/invitro_trace_function .
+	docker push ghcr.io/vhive-serverless/invitro_trace_function:latest
 
 # Used for measuring cold start latency
 empty-firecracker:
 	docker build --build-arg FUNC_TYPE=EMPTY \
 		--build-arg FUNC_PORT=50051 \
 		-f Dockerfile.trace \
-		-t cvetkovic/empty_function_firecracker .
-	docker push cvetkovic/empty_function_firecracker:latest
+		-t ghcr.io/vhive-serverless/invitro_empty_function_firecracker:latest .
+	docker push ghcr.io/vhive-serverless/invitro_empty_function_firecracker:latest
 
 # Used for measuring cold start latency
 empty-container:
 	docker build --build-arg FUNC_TYPE=EMPTY \
 		--build-arg FUNC_PORT=80 \
 		-f Dockerfile.trace \
-		-t cvetkovic/empty_function .
-	docker push cvetkovic/empty_function:latest
+		-t ghcr.io/vhive-serverless/invitro_empty_function:latest .
+	docker push ghcr.io/vhive-serverless/invitro_empty_function:latest
 
 wimpy:
 	docker build -f Dockerfile.wimpy -t hyhe/wimpy .

--- a/data/traces/reference/.gitattributes
+++ b/data/traces/reference/.gitattributes
@@ -1,0 +1,1 @@
+*.tar.gz filter=lfs diff=lfs merge=lfs -text

--- a/docs/loader.md
+++ b/docs/loader.md
@@ -140,8 +140,12 @@ For testing cold start performance:
 * `empty-container` - for regular containers - returns immediately
 
 ```bash
-$ make build <trace-firecracker|trace-container|empty-firecracker|empty-container>
+$ make <trace-firecracker|trace-container|empty-firecracker|empty-container>
 ```
+
+Pushing the images will require a write access to Github packages connected to this repository. Please refer to 
+[this guide](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic)
+for authentication instructions.
 
 ## Clean up between runs
 

--- a/workloads/container/trace_func_go.yaml
+++ b/workloads/container/trace_func_go.yaml
@@ -21,7 +21,7 @@ spec:
       nodeSelector:
         loader-nodetype: worker
       containers:
-        - image: docker.io/cvetkovic/trace_function:latest
+        - image: ghcr.io/vhive-serverless/invitro_trace_function:latest
           # imagePullPolicy: Always  # No need if the tag is `latest`.
           ports:
             - name: h2c  # For gRPC support

--- a/workloads/firecracker/trace_func_go.yaml
+++ b/workloads/firecracker/trace_func_go.yaml
@@ -27,7 +27,7 @@ spec:
             - name: GUEST_PORT # Port on which the firecracker-containerd container is accepting requests.
               value: "50051"
             - name: GUEST_IMAGE # Container image to use for firecracker-containerd container.
-              value: "cvetkovic/trace_function_firecracker:latest"
+              value: "ghcr.io/vhive-serverless/invitro_trace_function_firecracker:latest"
             - name: ITERATIONS_MULTIPLIER
               value: "102"
           resources:


### PR DESCRIPTION
## Summary

Move function container images to Github Container Registry. This will simplify updates of the images.

## Implementation Notes :hammer_and_pick:

* Change to Makefile and Dockerfile to create images linked to Invitro repo in vhive-serverless packages.

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* Change of the function images names.
