### PR TITLE
Update e2e test to use test config.json

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -59,10 +59,10 @@ jobs:
           kubectl label node knative-control-plane loader-nodetype=worker
 
       - name: Build and run loader
-        run: go run cmd/loader.go --config cmd/config.json
+        run: go run cmd/loader.go --config pkg/config/test_config.json
 
       - name: Check the output
-        run: test $(grep true data/out/experiment_duration_2.csv | wc -l) -eq 0 # test the output file for errors (true means failure to invoke)
+        run: test -f "data/out/experiment_duration_5.csv" && test $(grep true data/out/experiment_duration_5.csv | wc -l) -eq 0 # test the output file for errors (true means failure to invoke)
 
       - name: Print logs
         if: ${{ always() }}


### PR DESCRIPTION
## Summary

Update end-to-end test to use fixed test config. After update to default `config.json` the test was failing silently (e.g. [this one](https://github.com/vhive-serverless/invitro/actions/runs/6628346915/job/18005215258#step:10:11)).
