### PR TITLE
fix kubeadm config yaml and version up kubeadm

### DIFF
--- a/config/kubeadm_init.yaml
+++ b/config/kubeadm_init.yaml
@@ -1,32 +1,33 @@
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: 10.0.1.1
+
+---
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration
 apiServer:
   extraArgs:
     authorization-mode: Node,RBAC
   timeoutForControlPlane: 4m0s  # The timeout that we wait for the API server to appear
-localAPIEndpoint:
-  advertiseAddress: 10.0.1.1
 certificatesDir: /etc/kubernetes/pki
 clusterName: kubernetes
-dns:
-  type: CoreDNS
+dns: {}
 etcd:
   local:
     dataDir: /var/lib/etcd
-imageRepository: k8s.gcr.io
-# kubernetesVersion: v1.20.6
-# kubernetesVersion: v1.20.15
-kubernetesVersion: v1.23.0
+imageRepository: registry.k8s.io
+kubernetesVersion: v1.25.9
 networking:
   dnsDomain: cluster.local
   podSubnet: 10.168.0.0/16
   serviceSubnet: 10.96.0.0/12
 controllerManager:
   extraArgs:
-    bind-address: "0.0.0.0"  # This allows scheduler and controllers to be scraped on other ports and nodes.
+    bind-address: 0.0.0.0 # This allows scheduler and controllers to be scraped on other ports and nodes.
 scheduler:
   extraArgs:
-    bind-address: "0.0.0.0"
+    bind-address: 0.0.0.0
 
 ---
 # Configure kubelet for large pod limits.

--- a/config/metrics_server_components.yaml
+++ b/config/metrics_server_components.yaml
@@ -139,7 +139,7 @@ spec:
         - --metric-resolution=15s
         - --kubelet-insecure-tls=true
         - --logtostderr
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/config/prometh_stack_values.yaml
+++ b/config/prometh_stack_values.yaml
@@ -1490,7 +1490,7 @@ prometheusOperator:
     patch:
       enabled: true
       image:
-        registry: k8s.gcr.io
+        registry: registry.k8s.io
         repository: ingress-nginx/kube-webhook-certgen
         tag: v1.3.0
         sha: ""


### PR DESCRIPTION
While deploying Prometheus, due to the vHive k8s version up, Kubeadm caused a version collision and created an error:

```
This version of Kubeadm only supports deploying clusters with the control plane version >= 1.24.0. Current version: v1.23.0 
...
[upgrade/config] FATAL
```
Therefore, I bumped up the Kubeadm version to meet the dependency of the installed Kubernetes version.

---

Also, there was a misconfiguration in `config/kubeadm_init.yaml`:
```
localAPIEndpoint:
  advertiseAddress: 10.0.1.1
```
should be under
`kind: InitConfiguration`, not `kind: ClusterConfiguration`
Also, while doing so, upgraded Api Version to `kubeadm.k8s.io/v1beta3`, as `kubeadm.k8s.io/v1beta2` is deprecated.

Now, installation is done without any errors.
