### PR TITLE
Deploying multiple `serverless.yml` to handle large number of functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,7 @@ Temporary Items
 .venv
 
 # Serverless Framework Deployment
-serverless.yml
+serverless*.yml
 .serverless
 
 # Byte-compiled / optimized / DLL files

--- a/pkg/driver/deployment_awslambda.go
+++ b/pkg/driver/deployment_awslambda.go
@@ -24,7 +24,8 @@ func DeployFunctionsAWSLambda(functions []*common.Function) {
 			// Create serverless.yml file
 			serverless := Serverless{}
 			serverless.CreateHeader(index, provider)
-			serverless.AddPackagePattern("./pkg/server/trace-func-go/aws/**")
+			serverless.AddPackagePattern("!**")
+			serverless.AddPackagePattern("./server/trace-func-go/aws/trace_func")
 
 			for i := 0; i < len(functionGroup); i++ {
 				serverless.AddFunctionConfig(functionGroup[i], provider)
@@ -75,11 +76,13 @@ func CleanAWSLambda(functions []*common.Function) {
 	log.Debugf("Deleted %d out of %d serverless.yml files", counter, len(functionGroups))
 }
 
-// separateFunctions splits functions into groups of 50 due to AWS CloudFormation template resource limit (500 resources per template)
+// separateFunctions splits functions into groups of 70 due to AWS CloudFormation template resource limit (500 resources per template) and IAM maximum policy size (10240 bytes)
 func separateFunctions(functions []*common.Function) [][]*common.Function {
 	var functionGroups [][]*common.Function
-	for i := 0; i < len(functions); i += 50 {
-		end := i + 50
+	groupSize := 70
+
+	for i := 0; i < len(functions); i += groupSize {
+		end := i + groupSize
 		if end > len(functions) {
 			end = len(functions)
 		}

--- a/pkg/driver/serverless_config.go
+++ b/pkg/driver/serverless_config.go
@@ -59,6 +59,7 @@ type slsFunction struct {
 	Description string     `yaml:"description"`
 	Name        string     `yaml:"name"`
 	Events      []slsEvent `yaml:"events"`
+	Timeout     string     `yaml:"timeout"`
 }
 
 type slsEvent struct {
@@ -105,14 +106,16 @@ func (s *Serverless) AddFunctionConfig(function *common.Function, provider strin
 	events := []slsEvent{{slsHttpApi{Path: "/" + function.Name, Method: "GET"}}}
 
 	var handler string
+	var timeout string
 	switch provider {
 	case "aws":
 		handler = "server/trace-func-go/aws/trace_func"
+		timeout = "29"
 	default:
 		log.Fatalf("AddFunctionConfig could not recognize provider %s", provider)
 	}
 
-	f := &slsFunction{Handler: handler, Name: function.Name, Events: events}
+	f := &slsFunction{Handler: handler, Name: function.Name, Events: events, Timeout: timeout}
 	s.Functions[function.Name] = f
 }
 

--- a/pkg/driver/serverless_config.go
+++ b/pkg/driver/serverless_config.go
@@ -45,10 +45,11 @@ type Serverless struct {
 }
 
 type slsProvider struct {
-	Name    string `yaml:"name"`
-	Runtime string `yaml:"runtime"`
-	Stage   string `yaml:"stage"`
-	Region  string `yaml:"region"`
+	Name             string `yaml:"name"`
+	Runtime          string `yaml:"runtime"`
+	Stage            string `yaml:"stage"`
+	Region           string `yaml:"region"`
+	VersionFunctions bool   `yaml:"versionFunctions"`
 }
 
 type slsPackage struct {
@@ -77,10 +78,11 @@ func (s *Serverless) CreateHeader(index int, provider string) {
 	s.Service = fmt.Sprintf("loader-%d", index)
 	s.FrameworkVersion = "3"
 	s.Provider = slsProvider{
-		Name:    provider,
-		Runtime: "go1.x",
-		Stage:   "dev",
-		Region:  "us-east-1",
+		Name:             provider,
+		Runtime:          "go1.x",
+		Stage:            "dev",
+		Region:           "us-east-1",
+		VersionFunctions: false,
 	}
 	s.Functions = map[string]*slsFunction{}
 }
@@ -104,7 +106,10 @@ func (s *Serverless) AddPackagePattern(pattern string) {
 // AddFunctionConfig adds the function configuration for serverless.com deployment
 func (s *Serverless) AddFunctionConfig(function *common.Function, provider string) {
 
-	events := []slsEvent{{slsHttpApi{Path: "/" + function.Name, Method: "GET"}}}
+	// Extract 0 from trace-func-0-2642643831809466437 by splitting on "-"
+	shortName := strings.Split(function.Name, "-")[2]
+
+	events := []slsEvent{{slsHttpApi{Path: "/" + shortName, Method: "GET"}}}
 
 	var handler string
 	var timeout string
@@ -116,7 +121,7 @@ func (s *Serverless) AddFunctionConfig(function *common.Function, provider strin
 		log.Fatalf("AddFunctionConfig could not recognize provider %s", provider)
 	}
 
-	f := &slsFunction{Handler: handler, Name: function.Name, Events: events, Timeout: timeout}
+	f := &slsFunction{Handler: handler, Name: shortName, Events: events, Timeout: timeout}
 	s.Functions[function.Name] = f
 }
 

--- a/pkg/driver/trace_driver.go
+++ b/pkg/driver/trace_driver.go
@@ -669,6 +669,6 @@ func (d *Driver) RunExperiment(iatOnly bool, generated bool) {
 	} else if d.Configuration.LoaderConfiguration.Platform == "OpenWhisk" {
 		CleanOpenWhisk(d.Configuration.Functions)
 	} else if d.Configuration.LoaderConfiguration.Platform == "AWSLambda" {
-		CleanAWSLambda()
+		CleanAWSLambda(d.Configuration.Functions)
 	}
 }


### PR DESCRIPTION
## Summary

Fixed 2 main issues with regards to **AWS Lambda deployment**:
1. Multiple `serverless.yml` to handle any number of Lambda functions
**Problem:** Unable to deploy large number of AWS Lambda functions in a single `serverless.yml` file due to limitations
**Solution:** 
    1. Minimised file size of deployed serverless zip through `package.patterns` in `serverless.yml` (to avoid the [75GB Lambda Code storage limit](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html))
    2. Disabled [Lambda versioning](https://www.serverless.com/framework/docs/providers/aws/guide/functions#:~:text=Versioning%20Deployed%20Functions) through `provider.versionFunctions` in `serverless.yml`  (to minimise resources required per `.yml` file and avoid [CloudFormation 500 Resource Limit](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html#:~:text=AWS%20CloudFormation%20template.-,500%20resources,-To%20specify%20more))
    3. Split invocation traces into groups of 70 functions (to fit within [IAM maximum policy size of 10,240 bytes](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#:~:text=Role%20policy%20size%20can%27t%20exceed%2010%2C240%20characters.))
    4. Deploy all groups in parallel of 2 `serverless.yml` files (to avoid Out Of Memory Error while reducing deployment time)
**Note: Parallel deployment of 2 files is adjustable depending on the available memory of the compute instance

2. Added **Lambda timeout duration** to fit within **API Gateway timeout**
**Problem:** Current invocation failures could be due to many reasons such as
**(1) AWS Lambda timeout -** AWS Lambda functions automatically timeout and fail if `requestedDuration` is more than AWS Lambda's default 6s
**(2) AWS API Gateway timeout -** AWS API Gateway automatically timeout and fail if `requestedDuration` is more than AWS API Gateway's accepted 29s
**Solution:** Minimise invocation failures by explicitly limiting Lambda functions' timeout duration to 29s. Note that if `requestedDuration` > 29s, program would still run and Lambda would timeout at 29s, returning `5xx` error status code.