### PR TITLE
Chore: Fix Missing MIT License in Files, trace_synthesizer documentation & defining explicit behaviour 

### DIFF
--- a/.github/configs/wordlist.txt
+++ b/.github/configs/wordlist.txt
@@ -751,3 +751,4 @@ ethz
 lazar
 xvzf
 untar
+len

--- a/pkg/driver/serverless_config.go
+++ b/pkg/driver/serverless_config.go
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 EASL and the vHive community
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package driver
 
 import (

--- a/server/trace-func-go/aws/trace_func.go
+++ b/server/trace-func-go/aws/trace_func.go
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 EASL and the vHive community
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package main
 
 import (

--- a/tools/trace_synthesizer/README.md
+++ b/tools/trace_synthesizer/README.md
@@ -47,6 +47,26 @@ optional arguments:
 ### Example
 
 ```bash
-python3 . generate -f 2 -b 10 -t 20 -s 5 -dur 3 -e 500 -mem 350 -o example -m 0
+# Normal mode is to invoke all functions at increasing rate
+# E.g. For 2 functions, starting at 10 RPS and maximum of 20 RPS with step = 5, each function will be invoked 600 times at 1st, 2nd and 3rd minute; 900 times at 4th, 5th and 6th minute; 1200 times at 7th, 8th and 9th minute
+# RPS is multiplied by 60 by default, to change this, edit `ipm = [60 * x for x in rps]` in `synthesizer.py`
+# `-dur` determines how long each RPS should continue for (in minutes) before increasing to the next RPS step
+python3 . generate -f 2 -b 10 -t 20 -s 5 -dur 3 -e 500 -mem 350 -o example_normal -m 0
+
+# RPS Sweep mode is to spread the invocations across all functions evenly
+# E.g. Across the default 10 minute cycle (i.e. `padding=10`) and for 2 functions, functions will be invoked one by one every 5 minutes
+# E.g. Across a 15 minute cycle (i.e. `padding=15`) and for 5 functions, functions will be invoked one by one every 3 minutes
+
+# For RPS Sweep mode, ensure that -dur value matches the number of minutes in `base_traces\inv.csv`
+# If an error occurs, you may edit `padding=10` in `synthesizer.py` such that duration is divisible by padding (e.g. duration=1440 is divisible by padding=10)
+python3 . generate -f 2 -b 10 -t 20 -s 5 -dur 1440 -e 500 -mem 350 -o example_sweep -m 1
+
+# Burst mode is to invoke all the functions once at the same time
+# E.g. Across the default 3 minute cycle (i.e. `p = [1, 0, 0]`) and for 2 functions, all 2 functions will be invoked once every 3 minute
+# E.g. Across a 5 minute cycle (i.e. `p = [1, 0, 0, 0, 0]`) and for 5 functions, all 5 functions will be invoked once every 5 minute
+
+# For Burst mode, ensure that -dur value matches the number of minutes in `base_traces\inv.csv`
+# If an error occurs, you may edit `p = [1, 0, 0]` in `synthesizer.py` such that duration is divisible by length of `p` (e.g. duration=1440 is divisible by len(p)=3)
+python3 . generate -f 2 -b 10 -t 20 -s 5 -dur 1440 -e 500 -mem 350 -o example_burst -m 2
 ```
 

--- a/tools/trace_synthesizer/__main__.py
+++ b/tools/trace_synthesizer/__main__.py
@@ -128,6 +128,7 @@ def main():
         required=True,
         type=int,
         metavar='integer',
+        choices=[0, 1, 2],
         help='Normal [0]; RPS sweep [1]; Burst [2]'
     )
 

--- a/tools/trace_synthesizer/synthesizer.py
+++ b/tools/trace_synthesizer/synthesizer.py
@@ -94,7 +94,7 @@ def generate(args):
             pattern = p * repetitions
 
             invArr.extend(pattern)
-        else:
+        elif mode == 2:
             p = [1, 0, 0]
 
             repetitions = int(duration / len(p))


### PR DESCRIPTION
## Summary

Chore to add MIT license to some files, improve documentation and code of trace_synthesizer tool (explicitly define code behaviour)

## Implementation Notes :hammer_and_pick:

* N/A

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* Using mode >= 3 for trace_synthesizer tool will lead to runtime failure instead of defaulting to mode 2
