### PR TITLE
Fix multi-node cluster creation script

### DIFF
--- a/scripts/setup/setup.cfg
+++ b/scripts/setup/setup.cfg
@@ -2,5 +2,4 @@ VHIVE_BRANCH='main'
 LOADER_BRANCH='main'
 CLUSTER_MODE='container' # choose from {container, firecracker, firecracker_snapshots}
 PODS_PER_NODE=240
-GITHUB_TOKEN=$HOME/.git_token_loader
 DEPLOY_PROMETHEUS=false


### PR DESCRIPTION
## Summary

Fix bugs introduced into the setup script during the update to the mainstream vHive version: resource requests and labels. Also, remove the GitHub token (since invitro is public, we don't need it every time).

## Implementation Notes :hammer_and_pick:

* Move cloning repositories into `common_init` together with node stabilization (stabilization being too late in the setup was the reason for resource requests exceeding the capacity, closes #330)
* Fix master node role to control-plane, because of that, labeling wasn't working properly
* Since we don't need the SSH keys to clone the repo, remove the token completely, closes #292
* Fix labeling, so it won't create problems with redirects (remove `tmp` file, it was conflicting with collecting the logs of the script)

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A
