### PR TITLE
Fix: Use Lambda URL to bypass Gateway timeout limit

### DIFF
--- a/pkg/driver/deployment_awslambda.go
+++ b/pkg/driver/deployment_awslambda.go
@@ -3,7 +3,6 @@ package driver
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/vhive-serverless/loader/pkg/common"
-	"strings"
 	"sync"
 	"sync/atomic"
 )
@@ -48,10 +47,7 @@ func DeployFunctionsAWSLambda(functions []*common.Function) {
 					} else {
 						atomic.AddUint64(&counter, 1)
 						for i := 0; i < len(functionGroup); i++ {
-							// Extract 0 from trace-func-0-2642643831809466437 by splitting on "-"
-							shortName := strings.Split(functionGroup[i].Name, "-")[2]
-
-							functionGroup[i].Endpoint = functionToURLMapping[shortName]
+							functionGroup[i].Endpoint = functionToURLMapping[i]
 							log.Debugf("Function %s set to %s", functionGroup[i].Name, functionGroup[i].Endpoint)
 						}
 					}

--- a/pkg/driver/http_client.go
+++ b/pkg/driver/http_client.go
@@ -194,7 +194,7 @@ func httpInvocation(dataString string, function *common.Function, AnnounceDoneEx
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
-		log.Debugf("http timeout exceeded for function %s - %s", function.Name, err)
+		log.Debugf("http request for function %s failed - %s", function.Name, err)
 
 		record.ResponseTime = time.Since(start).Microseconds()
 		record.ConnectionTimeout = true
@@ -205,7 +205,7 @@ func httpInvocation(dataString string, function *common.Function, AnnounceDoneEx
 	}
 
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		log.Debugf("http request for function %s failed - error code: %d", function.Name, res.StatusCode)
+		log.Debugf("http request for function %s failed - error code: %s", function.Name, res.Status)
 
 		record.ResponseTime = time.Since(start).Microseconds()
 		record.ConnectionTimeout = true


### PR DESCRIPTION
## Summary

**Fixed AWS API Gateway timeout limit for AWS Lambda deployment, by replacing API Gateway with Lambda function URL to generate invocation URL**

**Problem:** Previous deployment with API Gateway (with differing page paths for each Lambda function) can only handle invocations within 29 seconds due to gateway timeout. However, actual traces involve invocations longer than 29s. Although our current code filters for invocations under 1 minute, it is not sufficient to address the problem.

**Included minor fixes to improve the logging description of errors.

## Implementation Notes :hammer_and_pick:

**Solution:** Utilise AWS' Lambda function URL feature to increase the maximum invocation duration to 15 minutes (same as Lambda execution timeout limit). 

Therefore, program can now handle any `requestedDuration` within 15 minutes and the resulting function URLs no longer share the same domain name (unlike previous approach where different Lambda functions share the same domain name due to usage of an API Gateway and only differ for the page path)

## External Dependencies :four_leaf_clover:

* Relies on Serverless.com framework for deployment, and that resulting function URLs are displayed in console/terminal in sequence (to map the function URL to the correct Lambda function)

## Breaking API Changes :warning:

* N/A
