### PR TITLE
Fix: Updated CommitLint to Node v20

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: "14"
+          node-version: "20"
 
       - name: Install Commitlint
         run: sudo npm install -g @commitlint/cli


### PR DESCRIPTION
## Summary

**Fixed CI pipeline error for `CommitLint` due to Node versioning.**

Error Message:
```
Run commitlint --config /home/runner/work/invitro/invitro/.github/configs/commitlint.config.js --help-url 'https://stackoverflow.com/a/45974435' --from HEAD~1 --to HEAD --verbose
internal/process/esm_loader.js:7[4](https://github.com/vhive-serverless/invitro/actions/runs/8131260484/job/22220380411?pr=384#step:5:5)
    internalBinding('errors').triggerUncaughtException(
                              ^

Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:timers/promises
    at new NodeError (internal/errors.js:322:7)
    at Loader.builtinStrategy (internal/modules/esm/translators.js:289:11)
    at new ModuleJob (internal/modules/esm/module_job.js:63:26)
    at Loader.getModuleJob (internal/modules/esm/loader.js:2[5](https://github.com/vhive-serverless/invitro/actions/runs/8131260484/job/22220380411?pr=384#step:5:6)8:11)
    at async ModuleWrap.<anonymous> (internal/modules/esm/module_job.js:[7](https://github.com/vhive-serverless/invitro/actions/runs/8131260484/job/22220380411?pr=384#step:5:8)[8](https://github.com/vhive-serverless/invitro/actions/runs/8131260484/job/22220380411?pr=384#step:5:9):21)
    at async Promise.all (index 1)
    at async link (internal/modules/esm/module_job.js:83:[9](https://github.com/vhive-serverless/invitro/actions/runs/8131260484/job/22220380411?pr=384#step:5:10)) {
  code: 'ERR_UNKNOWN_BUILTIN_MODULE'
}
Error: Process completed with exit code 1.
```

## Implementation Notes :hammer_and_pick:

* Updated the Node version running `CommitLint` to the latest LTS version 20

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A
