### PR TITLE
Fix vhive version to 1.6.1

### DIFF
--- a/scripts/setup/setup.cfg
+++ b/scripts/setup/setup.cfg
@@ -1,4 +1,4 @@
-VHIVE_BRANCH='main'
+VHIVE_BRANCH='v1.6.1'
 LOADER_BRANCH='main'
 CLUSTER_MODE='container' # choose from {container, firecracker, firecracker_snapshots}
 PODS_PER_NODE=240


### PR DESCRIPTION
## Summary

vHive is experiencing a version bumping: https://github.com/vhive-serverless/vHive/pull/943
This would cause invitro inconsistency problem with vHive. So before the PR is merged, we release a v1.6.1 release and direct invitro to use it.

## Implementation Notes :hammer_and_pick:

Change the vhive branch in setup script from `main` to `1.6.1`

## External Dependencies :four_leaf_clover:

N/A

## Breaking API Changes :warning:

N/A

*Simply specify none (N/A) if not applicable.*
