### PR TITLE
Fix: AWS Golang Runtime Deprecation (zip deployment)

### DIFF
--- a/pkg/driver/serverless_config.go
+++ b/pkg/driver/serverless_config.go
@@ -70,7 +70,7 @@ func (s *Serverless) CreateHeader(index int, provider string) {
 	s.FrameworkVersion = "3"
 	s.Provider = slsProvider{
 		Name:             provider,
-		Runtime:          "go1.x",
+		Runtime:          "provided.al2023", // Golang runtime deprecated, refer to https://aws.amazon.com/fr/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/
 		Stage:            "dev",
 		Region:           "us-east-1",
 		VersionFunctions: false,
@@ -104,7 +104,7 @@ func (s *Serverless) AddFunctionConfig(function *common.Function, provider strin
 	var timeout string
 	switch provider {
 	case "aws":
-		handler = "server/trace-func-go/aws/trace_func"
+		handler = "bootstrap"
 		timeout = "900"
 	default:
 		log.Fatalf("AddFunctionConfig could not recognize provider %s", provider)


### PR DESCRIPTION
## Summary

Code deployment to AWS is failing as AWS has deprecated the `go1.x` runtime in line with the end-of-life of Amazon Linux 1. We need to migrate from `go1.x` runtime to `provided.al2023` or `provided.al2` runtime to continue with zip deployment on Lambda.

Refer to AWS announcement blog for more details: https://aws.amazon.com/fr/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/

## Implementation Notes :hammer_and_pick:

As recommended in the above announcement blog:
- Updated the runtime to `provided.al2023`  for its longer support time
- Updated the handler and binary file name to `bootstrap`, and avoided nested file paths

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A
