### PR TITLE
Feature: Changed Support from Zip to Image Deployment on AWS via ECR

### DIFF
--- a/.github/configs/wordlist.txt
+++ b/.github/configs/wordlist.txt
@@ -273,6 +273,7 @@ https
 Hu
 Hyperparameter
 hyperparameter
+IAM
 Idgunji
 IEEE
 IEEEMicro

--- a/Dockerfile.trace.aws
+++ b/Dockerfile.trace.aws
@@ -1,0 +1,34 @@
+# Stage 0: Build #
+# Use the official Golang image to create a build artifact.
+# This is based on Debian and sets the GOPATH to /go.
+FROM golang:1.19 as BUILDER
+
+# Create and change to the app directory.
+WORKDIR /app
+
+# Retrieve application dependencies using go modules.
+# Allows container builds to reuse downloaded dependencies.
+COPY go.* ./
+RUN go mod download
+
+# Copy local code to the container image.
+COPY . ./
+
+# Build the binary.
+WORKDIR /app/server/trace-func-go/aws
+
+# -mod=readonly: ensures immutable go.mod and go.sum in container builds.
+# CGO_ENABLED=1: uses common libraries found on most major OS distributions.
+# GOARCH=amd64 GOGCCFLAGS=-m64: specifies x86, 64-bit GCC.
+RUN CGO_ENABLED=1 GOARCH=amd64 GOGCCFLAGS=-m64 GOOS=linux go build -mod=readonly -v -o server
+
+# Stage 1: Run #
+FROM debian:stable-slim
+
+# Copy the binary to the production image from the BUILDER stage.
+COPY --from=BUILDER /app/server/trace-func-go/aws/server /server
+
+# Run the web service on container startup.
+ENTRYPOINT ["/server"]
+
+LABEL org.opencontainers.image.source=https://github.com/vhive-serverless/invitro

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -92,3 +92,8 @@ const (
 	RequestedVsIssued RuntimeAssertType = 0
 	IssuedVsFailed    RuntimeAssertType = 1
 )
+
+const (
+	AwsRegion                  = "us-east-1"
+	AwsTraceFuncRepositoryName = "invitro_trace_function_aws"
+)

--- a/pkg/driver/deployment_awslambda.go
+++ b/pkg/driver/deployment_awslambda.go
@@ -1,19 +1,27 @@
 package driver
 
 import (
+	"fmt"
 	log "github.com/sirupsen/logrus"
 	"github.com/vhive-serverless/loader/pkg/common"
+	"os/exec"
+	"strings"
 	"sync"
 	"sync/atomic"
 )
 
+// DeployFunctionsAWSLambda deploys functions to AWS Lambda using the Serverless.com framework, with additional dependencies on AWS CLI, Docker
 func DeployFunctionsAWSLambda(functions []*common.Function) {
-	provider := "aws"
+	const provider = "aws"
 
-	functionGroups := separateFunctions(functions)
+	// Check if all required dependencies are installed, verify that AWS account is clean and ready for deployment
+	awsAccountId, functionGroups := initAWSLambda(functions, provider)
 
-	// Use goroutines to create multiple serverless.yml files, deploy functions in parallel, and ensure all finishes
-	// However, due to CPU and memory constraints, we will only deploy 2 serverless.yml files in parallel and wait for them to finish before deploying the next 2
+	// Create all the serverless.yml files
+	createSlsConfigFiles(functionGroups, provider, awsAccountId)
+
+	// Use goroutines to deploy functions in parallel, and ensure all finishes
+	// Due to CPU and memory constraints, by default, we will deploy 2 serverless.yml files in parallel and wait for them to finish before deploying the next 2
 	var wg sync.WaitGroup
 	var counter uint64 = 0
 	parallelDeployment := 2
@@ -24,26 +32,13 @@ func DeployFunctionsAWSLambda(functions []*common.Function) {
 				wg.Add(1)
 				go func(functionGroup []*common.Function, index int) {
 					defer wg.Done()
-					log.Debugf("Creating serverless-%d.yml", index)
-
-					// Create serverless.yml file
-					serverless := Serverless{}
-					serverless.CreateHeader(index, provider)
-					serverless.AddPackagePattern("!**")
-					serverless.AddPackagePattern("./server/trace-func-go/aws/trace_func")
-
-					for i := 0; i < len(functionGroup); i++ {
-						serverless.AddFunctionConfig(functionGroup[i], provider)
-					}
-
-					serverless.CreateServerlessConfigFile(index)
-
 					log.Debugf("Deploying serverless-%d.yml", index)
 					// Deploy serverless functions and update the function endpoints
 					functionToURLMapping := DeployServerless(index)
 
 					if functionToURLMapping == nil {
-						log.Fatalf("Failed to deploy serverless-%d.yml", index)
+						CleanAWSLambda(functions)                               // Clean up all deployed functions before exiting
+						log.Fatalf("Failed to deploy serverless-%d.yml", index) // Immediately terminate deployment for fast feedback
 					} else {
 						atomic.AddUint64(&counter, 1)
 						for i := 0; i < len(functionGroup); i++ {
@@ -58,10 +53,13 @@ func DeployFunctionsAWSLambda(functions []*common.Function) {
 		wg.Wait()
 	}
 
-	log.Debugf("Deployed %d out of %d serverless.yml files", counter, len(functionGroups))
+	log.Debugf("Deployed all %d serverless.yml files", len(functionGroups))
 }
 
+// CleanAWSLambda cleans up the AWS Lambda deployment environment by deleting all serverless.yml files and the ECR private repository
 func CleanAWSLambda(functions []*common.Function) {
+	cleanAWSElasticContainerRegistry()
+
 	functionGroups := separateFunctions(functions)
 
 	// Use goroutines to delete multiple serverless.yml files in parallel
@@ -76,7 +74,6 @@ func CleanAWSLambda(functions []*common.Function) {
 				wg.Add(1)
 				go func(index int) {
 					defer wg.Done()
-					log.Debugf("Undeploying serverless-%d.yml", index)
 					deleted := CleanServerless(index)
 					if deleted {
 						atomic.AddUint64(&counter, 1)
@@ -88,13 +85,154 @@ func CleanAWSLambda(functions []*common.Function) {
 		wg.Wait()
 	}
 
-	log.Debugf("Deleted %d out of %d serverless.yml files", counter, len(functionGroups))
+	if counter != uint64(len(functionGroups)) {
+		log.Errorf("Deleted %d out of %d serverless.yml files", counter, len(functionGroups))
+		return
+	}
+
+	log.Debugf("Deleted all serverless.yml files")
 }
 
-// separateFunctions splits functions into groups of 70 due to AWS CloudFormation template resource limit (500 resources per template) and IAM maximum policy size (10240 bytes)
+// cleanAWSElasticContainerRegistry cleans up the AWS Elastic Container Registry by deleting the private repository if it exists
+func cleanAWSElasticContainerRegistry() {
+	// Check if ECR private repository exists, if so, delete it
+	checkExistECRRepoCmd := exec.Command("aws", "ecr", "describe-repositories", "--repository-name", common.AwsTraceFuncRepositoryName, "--region", common.AwsRegion)
+	err := checkExistECRRepoCmd.Run()
+	if err == nil {
+		// Delete ECR private repository
+		deleteECRRepoCmd := exec.Command("aws", "ecr", "delete-repository", "--repository-name", common.AwsTraceFuncRepositoryName, "--region", common.AwsRegion, "--force")
+		err = deleteECRRepoCmd.Run()
+		if err != nil {
+			log.Errorf("Failed to delete ECR private repository: %s", err)
+		}
+	}
+}
+
+// cleanAWSCloudWatchLogGroups cleans up the AWS CloudWatch log groups by deleting all log groups with the prefix "/aws/lambda/trace-func-"
+func cleanAWSCloudWatchLogGroups() {
+	// Check if CloudWatch log groups exist, if so, delete them
+	logGroupPrefix := fmt.Sprintf("/aws/lambda/%s-", common.FunctionNamePrefix)
+
+	checkExistLogGroupsCmd := exec.Command("aws", "logs", "describe-log-groups", "--log-group-name-prefix", logGroupPrefix, "--query", "logGroups[*].logGroupName", "--output", "json")
+	stdOutstdErr, err := checkExistLogGroupsCmd.CombinedOutput()
+	if err == nil {
+		var logGroupNames []string
+
+		// Extract log group names from JSON output
+		// Example JSON output: ["/aws/lambda/trace-func-0", "/aws/lambda/trace-func-1"]
+		logGroupNamesRaw := strings.Split(string(stdOutstdErr), "\"")
+		for i := 1; i < len(logGroupNamesRaw); i += 2 {
+			logGroupNames = append(logGroupNames, logGroupNamesRaw[i])
+		}
+		log.Debugf("Found %d CloudWatch log groups to delete: %v", len(logGroupNames), logGroupNames)
+
+		for _, logGroupName := range logGroupNames {
+			deleteLogGroupCmd := exec.Command("aws", "logs", "delete-log-group", "--log-group-name", logGroupName)
+			err = deleteLogGroupCmd.Run()
+			if err != nil {
+				log.Fatalf("Failed to delete CloudWatch log group %s: %s", logGroupName, err)
+			}
+		}
+	}
+}
+
+// initAWSLambda initializes the AWS Lambda deployment environment by checking dependencies, cleaning up previous resources, and initialising ECR repository through initECRRepository
+func initAWSLambda(functions []*common.Function, provider string) (string, [][]*common.Function) {
+	// Check if all required dependencies are installed
+	log.Debug("Checking dependencies for AWS deployment")
+	checkDependencies()
+
+	// Clean up previous resources, if any
+	log.Debug("Checking and cleaning up previous AWS Lambda resources")
+	functionGroups := separateFunctions(functions)
+	createSlsConfigFiles(functionGroups, provider, "") // serverless.yml files created do not require AWS account ID
+	CleanAWSLambda(functions)
+	cleanAWSCloudWatchLogGroups() // Clean up CloudWatch log groups (in rare occasions, log groups persist even after `sls remove`)
+
+	// Create a Private ECR Repository and Upload the Docker Image
+	log.Debug("Initialising ECR Repository for AWS Lambda deployment")
+	awsAccountId := obtainAWSAccountId()
+	initECRRepository(awsAccountId)
+
+	log.Debug("AWS Lambda is ready for deployment")
+	return awsAccountId, functionGroups
+}
+
+// initECRRepository creates a private ECR repository and uploads the default Docker image to the repository using AWS CLI and Docker CLI, terminating the program if any command fails
+func initECRRepository(awsAccountId string) {
+	originalDockerImageUri := fmt.Sprintf("ghcr.io/vhive-serverless/%s:latest", common.AwsTraceFuncRepositoryName)
+	awsEcrRepositoryFormat := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", awsAccountId, common.AwsRegion)
+	uploadedDockerImageUri := fmt.Sprintf("%s/%s:latest", awsEcrRepositoryFormat, common.AwsTraceFuncRepositoryName)
+
+	createRepoCmd := exec.Command("aws", "ecr", "create-repository", "--repository-name", common.AwsTraceFuncRepositoryName, "--region", common.AwsRegion)
+	err := createRepoCmd.Run()
+	if err != nil {
+		log.Fatalf("Failed to create ECR private repository: %s", err)
+	}
+
+	dockerLoginECRCmd := exec.Command("sh", "-c", fmt.Sprintf("aws ecr get-login-password --region %s | docker login --username AWS --password-stdin %s", common.AwsRegion, awsEcrRepositoryFormat))
+	err = dockerLoginECRCmd.Run()
+	if err != nil {
+		log.Fatalf("Failed to log Docker into ECR private repository: %s", err)
+	}
+
+	pullImageCmd := exec.Command("docker", "pull", originalDockerImageUri)
+	err = pullImageCmd.Run()
+	if err != nil {
+		log.Fatalf("Failed to pull standard image from GHCR: %s", err)
+	}
+
+	updateImageTagCmd := exec.Command("docker", "tag", originalDockerImageUri, uploadedDockerImageUri)
+	err = updateImageTagCmd.Run()
+	if err != nil {
+		log.Fatalf("Failed to update image tag: %s", err)
+	}
+
+	uploadECRCmd := exec.Command("docker", "push", uploadedDockerImageUri)
+	err = uploadECRCmd.Run()
+	if err != nil {
+		log.Fatalf("Failed to upload image to ECR private repository: %s", err)
+	}
+}
+
+// checkDependencies checks if all required dependencies (AWS CLI, Docker CLI, Serverless.com framework) are installed, terminating the program if any command fails
+func checkDependencies() {
+	// Check if AWS CLI is installed
+	awsCliCheckCmd := exec.Command("aws", "--version")
+	err := awsCliCheckCmd.Run()
+	if err != nil {
+		log.Fatalf("AWS CLI is not installed: %s", err)
+	}
+
+	// Check if Docker is installed
+	dockerCheckCmd := exec.Command("docker", "--version")
+	err = dockerCheckCmd.Run()
+	if err != nil {
+		log.Fatalf("Docker is not installed: %s", err)
+	}
+
+	// Check if Serverless Framework is installed
+	serverlessCheckCmd := exec.Command("sls", "--version")
+	err = serverlessCheckCmd.Run()
+	if err != nil {
+		log.Fatalf("Serverless Framework is not installed: %s", err)
+	}
+}
+
+// obtainAWSAccountId retrieves the AWS account ID using the AWS CLI, terminating the program if the command fails
+func obtainAWSAccountId() string {
+	obtainAwdAccountIdCmd := exec.Command("aws", "sts", "get-caller-identity", "--query", "Account", "--output", "text")
+	awsAccountIdRaw, err := obtainAwdAccountIdCmd.CombinedOutput()
+	if err != nil {
+		log.Fatalf("Failed to retrieve AWS account ID: %s", err)
+	}
+	return strings.TrimSpace(string(awsAccountIdRaw))
+}
+
+// separateFunctions splits functions into groups of 60 due to AWS CloudFormation template resource limit (500 resources per template) and IAM maximum policy size (10240 bytes)
 func separateFunctions(functions []*common.Function) [][]*common.Function {
 	var functionGroups [][]*common.Function
-	groupSize := 70
+	groupSize := 60
 
 	for i := 0; i < len(functions); i += groupSize {
 		end := i + groupSize
@@ -105,4 +243,19 @@ func separateFunctions(functions []*common.Function) [][]*common.Function {
 	}
 
 	return functionGroups
+}
+
+// createSlsConfigFiles creates serverless.yml files for each group of functions
+func createSlsConfigFiles(functionGroups [][]*common.Function, provider string, awsAccountId string) {
+	for i := 0; i < len(functionGroups); i++ {
+		log.Debugf("Creating serverless-%d.yml", i)
+		serverless := Serverless{}
+		serverless.CreateHeader(i, provider)
+
+		for j := 0; j < len(functionGroups[i]); j++ {
+			serverless.AddFunctionConfig(functionGroups[i][j], provider, awsAccountId)
+		}
+
+		serverless.CreateServerlessConfigFile(i)
+	}
 }

--- a/scripts/setup/install_aws_dependencies.sh
+++ b/scripts/setup/install_aws_dependencies.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+#
+# MIT License
+#
+# Copyright (c) 2024 HySCALE
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+LOADER_NODE=$1
+GO_VERSION=1.21.9
+
+server_exec() {
+  ssh -oStrictHostKeyChecking=no -p 22 $LOADER_NODE $1;
+}
+
+# Check the architecture
+arch=`server_exec 'uname -m'`
+case $arch in
+  'x86_64')
+    arch='amd64'
+    ;;
+  'aarch64')
+    arch='arm64'
+    ;;
+  *)
+    echo "Unsupported architecture $arch"
+    exit 1
+    ;;
+esac
+
+# Obtain configuration variables
+DIR=$(cd "$(dirname ${BASH_SOURCE[0]})" > /dev/null 2>&1 && pwd)
+source "$DIR/setup.cfg"
+
+echo "Installing the dependencies for AWS deployment"
+
+# ========== Get loader ==========
+server_exec "git clone --depth=1 --branch=$LOADER_BRANCH https://github.com/vhive-serverless/invitro.git loader"
+echo "Installed the Github repository for the loader"
+
+# ========== Install AWS CLI ==========
+server_exec 'curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o /tmp/awscliv2.zip'
+server_exec 'unzip -q /tmp/awscliv2.zip -d /tmp'
+server_exec 'rm /tmp/awscliv2.zip'
+server_exec 'sudo /tmp/aws/install --update'
+server_exec 'rm -rf /tmp/aws/'
+echo "Installed AWS CLI"
+
+# ========== Install Docker ==========
+# Add Docker's official GPG key:
+server_exec 'sudo apt-get update'
+server_exec 'sudo apt-get install ca-certificates curl'
+server_exec 'sudo install -m 0755 -d /etc/apt/keyrings'
+server_exec 'sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc'
+server_exec 'sudo chmod a+r /etc/apt/keyrings/docker.asc'
+echo "Added Docker's official GPG key"
+
+# Add the repository to Apt sources:
+server_exec 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null'
+server_exec 'sudo apt-get update'
+echo "Added the repository to Apt sources"
+
+# To install the latest Docker version, run:
+server_exec 'sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin'
+
+# To use Docker as a non-root user, adding user to the docker group:
+server_exec 'sudo usermod -aG docker ${USER}'
+echo "Installed Docker"
+
+# ========== Install golang ==========
+server_exec "curl -L 'https://golang.org/dl/go$GO_VERSION.linux-$arch.tar.gz' -o /tmp/go.tar.gz"
+server_exec 'sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf /tmp/go.tar.gz'
+server_exec 'sudo rm -f /tmp/go.tar.gz'
+server_exec 'echo "export PATH=\$PATH:/usr/local/go/bin" >> ~/.profile'
+echo "Installed golang"
+
+# ========== Install serverless.com framework (as a standalone binary without node.js / npm dependencies) ==========
+server_exec 'curl -o- -L https://slss.io/install | VERSION=3.34.0 bash'
+# Do not require export PATH as the installation comes with it
+echo "Installed serverless.com framework"
+
+# ========== Check the installed versions ==========
+echo "Checking the installed versions:"
+server_exec 'source ~/.profile; aws --version'
+server_exec 'source ~/.profile; docker --version'
+server_exec 'source ~/.profile; serverless --version'
+server_exec 'source ~/.profile; go version'
+
+echo "Finished installing the dependencies for AWS deployment"


### PR DESCRIPTION
## Summary

Due to the following reasons, the zip deployment approach for AWS Lambda is no longer supported by our project. Instead, the image deployment via ECR will be adopted:

1. AWS deprecation of `go1.x` runtime (as highlighted in an earlier [PR](https://github.com/vhive-serverless/invitro/pull/398))
2. Limitations of zip deployment (primarily the maximum number of functions deployable due to [75GB code storage limit](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html))
3. Alignment to other existing image deployments

Refactored code to handle errors more gracefully.

## Implementation Notes :hammer_and_pick:

<b>New Feature: Image Deployment</b>
* Pulls the default image (built using `./Dockerfile.trace.aws` and `./server/trace-func-go/aws/trace_func.go`) from our [public GHCR repository](https://github.com/vhive-serverless/invitro/pkgs/container/invitro_trace_function_aws)
* Creates a private AWS ECR repository using AWS CLI and upload the above image using Docker CLI (Unable to directly use [non-AWS or public image repositories](https://repost.aws/questions/QUEgw2bC3aTV2hmssdD5bYfA/how-to-use-a-public-ecr-with-aws-lambda))
* Proceeds to generate and deploy the `serverless.yml` file defining the CloudFormation stack and continue with experiments/invocations

<b>Refactor: Error Handling</b>
* Checks for external dependencies such as AWS CLI, Docker CLI, Serverless.com framework
* Checks and cleans up previously-created AWS resources, if any
  > Notably, for the rare occasion where Log Groups in CloudWatch may persist even after a clean up via `sls remove`, the log group naming has been updated to `/aws/lambda/trace-func-<count>`. This allows us to clean up obsolete log group resources through prefix filtering.

  > As a result, the number of functions per serverless.yml has decreased from <b>70</b> to <b>60</b> to fit within [IAM maximum policy size of 10,240 bytes](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#:~:text=Role%20policy%20size%20can%27t%20exceed%2010%2C240%20characters.)
* Cleans up existing AWS resources when encountering a `log.Fatalf()` error
* Failure to set up the ideal AWS environment would lead to termination of the program. In other words, majority of the responsibility to avoid deployment errors lies in the environment initialisation phase.

## External Dependencies :four_leaf_clover:

* AWS CLI (new)
* Docker CLI (new)
* Serverless.com framework

## Breaking API Changes :warning:

* Zip deployment to AWS lambda is no longer supported
