### PR TITLE
Feature: Added End-to-End Integration Test for Cloud Deployment (AWS)

### DIFF
--- a/.github/workflows/e2e_aws.yaml
+++ b/.github/workflows/e2e_aws.yaml
@@ -1,0 +1,64 @@
+name: End-to-End AWS Tests
+
+on:
+ schedule:
+   - cron: "0 9 * * 1"
+ workflow_dispatch:
+ push:
+   branches: [main]
+ pull_request:
+   branches: [main]
+
+env:
+  GOOS: linux
+  GO111MODULE: on
+
+jobs:
+  test-aws:
+    name: Test AWS Cloud Deployment
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout GitHub Code
+        uses: actions/checkout@v3
+        with:
+          lfs: "true"
+
+      - name: Checkout LFS objects
+        run: git lfs checkout
+
+      # AWS CLI v2 and Docker Client & Server v24 are pre-installed
+      - name: Install Golang (Ubuntu 20.04 Cached Tool)
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.22
+
+      - name: Install Node.js (Ubuntu 20.04 Cached Tool)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Serverless.com Framework
+        run: sudo npm install -g serverless
+
+      - name: Update cmd/config.json for AWS Deployment
+        # Change "Platform": "Knative" to "Platform": "AWSLambda"
+        # Change "Granularity": "minute" to "Granularity": "second"
+        run: |
+          sed -i 's/"Platform": "Knative"/"Platform": "AWSLambda"/g' cmd/config.json
+          sed -i 's/"Granularity": "minute"/"Granularity": "second"/g' cmd/config.json
+
+      - name: Wait for any previous workflows to finish # Works at workflow level (i.e. only 1 e2e_aws.yml workflow can run at a time)
+        uses: ahmadnassri/action-workflow-queue@v1      # Separate workflows for cloud deployment to minimise runner wait time and billing cost
+        with:
+          timeout: 3600000  # 1 hour; else manually re-run the workflow
+          delay: 60000  # 1 minute
+
+      - name: Build and run loader
+        run: go run cmd/loader.go --config cmd/config.json
+
+      - name: Check the output
+        run: test -f "data/out/experiment_duration_5.csv" && test $(grep true data/out/experiment_duration_5.csv | wc -l) -eq 0 # test the output file for errors (true means failure to invoke)


### PR DESCRIPTION
## Summary

Includes an end-to-end CI/CD pipeline on GitHub Actions to test for AWS Lambda deployment.

## Implementation Notes :hammer_and_pick:

- To maintain cloud deployment isolation, we need to ensure a **limit of 1 concurrent cloud deployment**
- This is achieved using a 3rd party GitHub Action in the marketplace which:
  1. Checks for any existing **same-named workflows**
  2. **Enqueues** the new request if the above workflows are detected
  3. Poll for their turn periodically and maintain execution order/sequence for each enqueued workflow (polling interval specified at **1 minute**; for up to **60 minutes**)
- To minimise queue time (esp. during peak periods) and compute duration, we reduced the experiment duration of cloud deployments from 5 minute to 5 seconds by changing the `granularity` in `cmd/config.json`

**Note:** We had to adopt an external dependency as the [in-built GitHub option for concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency) at the job/workflow level does not provide the desired behaviour. With only a queue length of 1, when multiple workflows get queued, at most the current workflow in execution and the latest-queued workflow will be kept. All other workflows would be cancelled. (Read more [here](https://github.com/orgs/community/discussions/41518) or understand through an [example](https://github.com/orgs/community/discussions/12835)).

## External Dependencies :four_leaf_clover:

* [action-workflow-queue](https://github.com/ahmadnassri/action-workflow-queue)

## Breaking API Changes :warning:

* N/A
