### PR TITLE
solve the label issue of singlenode through affinity

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -55,7 +55,7 @@ jobs:
           KNATIVE_DOMAIN=$INGRESS_HOST.sslip.io
           kubectl patch configmap -n knative-serving config-domain -p "{\"data\": {\"$KNATIVE_DOMAIN\": \"\"}}"
           kubectl patch configmap -n knative-serving config-autoscaler -p "{\"data\": {\"allow-zero-initial-scale\": \"true\"}}"
-          kubectl patch configmap -n knative-serving config-features -p "{\"data\": {\"kubernetes.podspec-nodeselector\": \"enabled\"}}"
+          kubectl patch configmap -n knative-serving config-features -p "{\"data\": {\"kubernetes.podspec-affinity\": \"enabled\"}}"
           kubectl label node knative-control-plane loader-nodetype=worker
 
       - name: Build and run loader

--- a/config/prometh_values_kn.yaml
+++ b/config/prometh_values_kn.yaml
@@ -7,12 +7,26 @@ alertmanager:
   serviceMonitor:
     interval: "15s"
   alertmanagerSpec:
-    nodeSelector:
-      loader-nodetype: monitoring
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: loader-nodetype
+            operator: In
+            values:
+            - monitoring
+            - singlenode
 
 grafana:
-  nodeSelector:
-    loader-nodetype: monitoring
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: loader-nodetype
+          operator: In
+          values:
+          - monitoring
+          - singlenode
   serviceMonitor:
     interval: "15s"
     scrapeTimeout: "15s" # Cannot be larger than Prometheus scrape intervals
@@ -59,8 +73,15 @@ kubeProxy:
     interval: "15s"
 
 kube-state-metrics:
-  nodeSelector:
-      loader-nodetype: monitoring
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: loader-nodetype
+          operator: In
+          values:
+          - monitoring
+          - singlenode
   metricLabelsAllowlist:
     - pods=[*]
     - deployments=[app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/instance]
@@ -76,8 +97,15 @@ prometheus-node-exporter:
 prometheusOperator:
   admissionWebhooks:
     deployment:
-      nodeSelector:
-        loader-nodetype: monitoring
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: loader-nodetype
+              operator: In
+              values:
+              - monitoring
+              - singlenode
     patch:
       resources: 
         limits:
@@ -85,8 +113,15 @@ prometheusOperator:
           memory: 5Gi
         requests:
           memory: 150Mi 
-      nodeSelector:
-        loader-nodetype: monitoring
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: loader-nodetype
+              operator: In
+              values:
+              - monitoring
+              - singlenode
 
   serviceMonitor:
     interval: "15s"
@@ -97,8 +132,15 @@ prometheusOperator:
     requests:
       cpu: 100m
       memory: 100Mi
-  nodeSelector:
-    loader-nodetype: monitoring
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: loader-nodetype
+          operator: In
+          values:
+          - monitoring
+          - singlenode
 
   prometheusConfigReloader:
     resources:
@@ -115,8 +157,15 @@ prometheus:
 
   prometheusSpec:
     scrapeInterval: "15s"
-    nodeSelector:
-      loader-nodetype: monitoring
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: loader-nodetype
+            operator: In
+            values:
+            - monitoring
+            - singlenode
     serviceMonitorSelectorNilUsesHelmValues: false
     podMonitorSelectorNilUsesHelmValues: false
     walCompression: false

--- a/scripts/setup/create_multinode.sh
+++ b/scripts/setup/create_multinode.sh
@@ -254,8 +254,8 @@ function copy_k8s_certificates() {
     # Force placement of metrics collectors and instrumentation on the loader node and control plane on master
     label_nodes $MASTER_NODE $1 # loader node is second on the list, becoming first after arg shift
 
-    # patch knative to accept nodeselector
-    server_exec $MASTER_NODE "cd loader; kubectl patch configmap config-features -n knative-serving -p '{\"data\": {\"kubernetes.podspec-nodeselector\": \"enabled\"}}'"
+    server_exec $MASTER_NODE "kubectl patch configmap -n knative-serving config-features -p '{\"data\": {\"kubernetes.podspec-affinity\": \"enabled\"}}'"
+
 
     if [[ "$DEPLOY_PROMETHEUS" == true ]]; then
         $DIR/expose_infra_metrics.sh $MASTER_NODE

--- a/scripts/setup/rewrite_yaml_files.sh
+++ b/scripts/setup/rewrite_yaml_files.sh
@@ -56,23 +56,8 @@ cat serving-core.yaml |
             or .spec.template.metadata.labels.app == "domain-mapping"
             or .spec.template.metadata.labels.app == "domainmapping-webhook"
             or .spec.template.metadata.labels.app == "webhook"
-        ) | .spec.template.spec 
-    ) += {"nodeSelector": {"loader-nodetype": "master"}}' |
-    yq '
-    (
-        del
-        (
-            select
-            (
-                    .spec.template.metadata.labels.app == "activator"
-                or .spec.template.metadata.labels.app == "autoscaler"
-                or .spec.template.metadata.labels.app == "controller"
-                or .spec.template.metadata.labels.app == "domain-mapping"
-                or .spec.template.metadata.labels.app == "domainmapping-webhook"
-                or .spec.template.metadata.labels.app == "webhook"
-            ) | .spec.template.spec.affinity
-        )
-    )' |
+        ) | .spec.template.spec.affinity
+    ) = {"nodeAffinity": {"requiredDuringSchedulingIgnoredDuringExecution": {"nodeSelectorTerms": [{"matchExpressions": [{"key": "loader-nodetype", "operator": "In", "values": ["master", "singlenode"]}]}]}}}' |
     yq '
     (
         select

--- a/scripts/setup/setup.cfg
+++ b/scripts/setup/setup.cfg
@@ -1,4 +1,4 @@
-VHIVE_BRANCH='v1.7'
+VHIVE_BRANCH='v1.7.1'
 LOADER_BRANCH='main'
 CLUSTER_MODE='container' # choose from {container, firecracker, firecracker_snapshots}
 PODS_PER_NODE=240

--- a/workloads/container/trace_func_go.yaml
+++ b/workloads/container/trace_func_go.yaml
@@ -18,8 +18,16 @@ spec:
         autoscaling.knative.dev/target: $AUTOSCALING_TARGET
     spec:
       containerConcurrency: 1
-      nodeSelector:
-        loader-nodetype: worker
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: loader-nodetype
+                operator: In
+                values:
+                - worker
+                - singlenode
       containers:
         - image: ghcr.io/vhive-serverless/invitro_trace_function:latest
           # imagePullPolicy: Always  # No need if the tag is `latest`.


### PR DESCRIPTION
# solve the label issue of singlenode through affinity

## Summary

For multi-node clusters, we label nodes with three values for loader-nodetype: master, monitoring, and worker. In the single-node case, we cannot label the node with all three of them, which leads to issues with placement. To address this, we propose to use the node affinity option instead of node selectors. This should allow us to choose one of the labels.

## Implementation Notes :hammer_and_pick:

1. Create a new label: `singlenode`, to identify single-node instances.
2. Update the node selectors in the following three places to use node affinity with the old label and the new `singlenode` label:
   - Knative services (master)
   - Prometheus (monitoring)
   - Worker pods (worker)

## External Dependencies :four_leaf_clover:

N/A

## Breaking API Changes :warning:

N/A

