### PR TITLE
Feature: Added End-to-End Integration Test for Cloud Deployment (AWS)

### DIFF
--- a/.github/workflows/e2e_aws.yaml
+++ b/.github/workflows/e2e_aws.yaml
@@ -1,0 +1,65 @@
+name: End-to-End AWS Tests
+
+on:
+ workflow_dispatch:
+ push:
+   branches: [main]
+
+env:
+  GOOS: linux
+  GO111MODULE: on
+
+jobs:
+  test-aws:
+    name: Test AWS Cloud Deployment
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+      AWS_DEFAULT_REGION: "us-east-1"
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check if environment variables are set  # Fails workflow if the secrets are not set
+        # Checks for missing secrets due to branch being out of upstream repo (i.e. forked repo cannot access secrets in upstream repo)
+        run: |
+          if [[ -z "$AWS_ACCESS_KEY_ID" ]]; then
+            echo "AWS_ACCESS_KEY_ID is not set. Please check if secrets.AWS_ACCESS_KEY is in the repository. Note that forked repo cannot access secrets in upstream repo!"
+            exit 1
+          fi
+          if [[ -z "$AWS_SECRET_ACCESS_KEY" ]]; then
+              echo "AWS_SECRET_ACCESS_KEY is not set. Please check if secrets.AWS_SECRET_KEY is in the repository. Note that forked repo cannot access secrets in upstream repo!"
+              exit 1
+          fi
+
+      - name: Checkout GitHub Code
+        uses: actions/checkout@v3
+        with:
+          lfs: "true"
+
+      - name: Checkout LFS objects
+        run: git lfs checkout
+
+      # AWS CLI v2 and Docker Client & Server v24 are pre-installed
+      - name: Install Golang (Ubuntu 20.04 Cached Tool)
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21
+
+      - name: Install Node.js (Ubuntu 20.04 Cached Tool)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Serverless.com Framework
+        run: sudo npm install -g serverless
+
+      - name: Wait for any previous workflows to finish # Works at workflow level (i.e. only 1 e2e_aws.yml workflow can run at a time)
+        uses: ahmadnassri/action-workflow-queue@v1      # Separate workflows for cloud deployment to minimise runner wait time and billing cost
+        with:
+          timeout: 3600000  # 1 hour; else manually re-run the workflow
+          delay: 60000  # 1 minute
+
+      - name: Build and run loader      # Test the AWS deployment using pkg/test_config_aws.json
+        run: go run cmd/loader.go --config pkg/test_config_aws.json
+
+      - name: Check the output
+        run: test -f "data/out/experiment_duration_5.csv" && test $(grep true data/out/experiment_duration_5.csv | wc -l) -eq 0 # test the output file for errors (true means failure to invoke)

--- a/pkg/config/test_config_aws.json
+++ b/pkg/config/test_config_aws.json
@@ -1,0 +1,25 @@
+{
+  "Seed": 42,
+
+  "Platform": "AWSLambda",
+  "YAMLSelector": "container",
+  "EndpointPort": 80,
+
+  "TracePath": "data/traces/example",
+  "Granularity": "second",
+  "OutputPathPrefix": "data/out/experiment",
+  "IATDistribution": "equidistant",
+  "CPULimit": "1vCPU",
+  "ExperimentDuration": 5,
+  "WarmupDuration": 0,
+
+  "IsPartiallyPanic": false,
+  "EnableZipkinTracing": false,
+  "EnableMetricsScrapping": false,
+  "MetricScrapingPeriodSeconds": 15,
+  "AutoscalingMetric": "concurrency",
+
+  "GRPCConnectionTimeoutSeconds": 15,
+  "GRPCFunctionTimeoutSeconds": 900,
+  "DAGMode": false
+}


### PR DESCRIPTION
## Summary

Includes an end-to-end CI/CD workflow on GitHub Actions to test for AWS Lambda deployment.

This workflow is triggered only upon `push` to the `main` branch, or manually from the `Actions` tab.

## Implementation Notes :hammer_and_pick:

- As workflow is triggered only upon commit to `main` branch, PRs will not capture any failure in AWS end-to-end deployments before merging
  - Currently, workflow trigger is disabled on `pull_request` as secrets are not accessible from forked repository
  - As the code for AWS deployment is rather localised, the above workflow trigger setting will minimise any disruptions to developers
  - If required, developers can manually trigger the workflow under the `Actions` tab
- The required secrets (AWS credentials) will be verified prior to running the workflow
  - If missing / not set, workflow will fail as early as possible
- To maintain cloud deployment isolation, we need to ensure a **limit of 1 concurrent cloud deployment**
  - This is achieved using a 3rd party GitHub Action in the marketplace which:
    1. Checks for any existing **same-named workflows**
    2. **Enqueues** the new request if the above workflows are detected
    3. Poll for their turn periodically and maintain execution order/sequence for each enqueued workflow (polling interval specified at **1 minute**; for up to **60 minutes**)
  - To minimise queue time (esp. during peak periods) and compute duration, we reduced the experiment duration of AWS deployment from 5 minutes to 5 seconds by using `pkg/config/test_config_aws.json`

**Note:** We had to adopt an external dependency as the [in-built GitHub option for concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency) at the job/workflow level does not provide the desired behaviour. With only a queue length of 1, when multiple workflows get queued, at most the current workflow in execution and the latest-queued workflow will be kept. All other workflows would be cancelled. (Read more [here](https://github.com/orgs/community/discussions/41518) or understand through an [example](https://github.com/orgs/community/discussions/12835)).

## External Dependencies :four_leaf_clover:

* [action-workflow-queue](https://github.com/ahmadnassri/action-workflow-queue)

## Breaking API Changes :warning:

* N/A
