### PR TITLE
Add VHIVE_REPO and LOADER_REPO to setup script config

### DIFF
--- a/scripts/setup/create_multinode.sh
+++ b/scripts/setup/create_multinode.sh
@@ -58,7 +58,7 @@ server_exec() {
 
 common_init() {
     internal_init() {
-        server_exec $1 "git clone --branch=$VHIVE_BRANCH https://github.com/vhive-serverless/vhive"
+        server_exec $1 "git clone --branch=$VHIVE_BRANCH $VHIVE_REPO"
 
         server_exec $1 "pushd ~/vhive/scripts > /dev/null && ./install_go.sh && source /etc/profile && go build -o setup_tool && ./setup_tool setup_node ${OPERATION_MODE} && popd > /dev/null"
         
@@ -189,7 +189,7 @@ function extend_CIDR() {
 }
 
 function clone_loader() {
-    server_exec $1 "git clone --depth=1 --branch=$LOADER_BRANCH https://github.com/vhive-serverless/invitro.git loader"
+    server_exec $1 "git clone --depth=1 --branch=$LOADER_BRANCH $LOADER_REPO loader"
     server_exec $1 'echo -en "\n\n" | sudo apt-get install -y python3-pip python-dev'
     server_exec $1 'cd; cd loader; pip install -r config/requirements.txt'
 }

--- a/scripts/setup/create_singlenode_container.sh
+++ b/scripts/setup/create_singlenode_container.sh
@@ -36,12 +36,12 @@ server_exec() {
 {
     # Spin up vHive under container mode.
     server_exec 'sudo DEBIAN_FRONTEND=noninteractive apt-get autoremove' 
-    server_exec "git clone --branch=$VHIVE_BRANCH https://github.com/ease-lab/vhive"
+    server_exec "git clone --branch=$VHIVE_BRANCH $VHIVE_REPO"
 
     server_exec "pushd ~/vhive/scripts > /dev/null && ./install_go.sh && source /etc/profile && go build -o setup_tool && ./setup_tool setup_node stock-only && popd > /dev/null"
 
     # Get loader and dependencies.
-    server_exec "git clone --branch=$LOADER_BRANCH https://github.com/vhive-serverless/invitro.git loader"
+    server_exec "git clone --branch=$LOADER_BRANCH $LOADER_REPO loader"
     server_exec 'echo -en "\n\n" | sudo apt-get install python3-pip python-dev'
     server_exec 'cd; cd loader; pip install -r config/requirements.txt'
     

--- a/scripts/setup/install_aws_dependencies.sh
+++ b/scripts/setup/install_aws_dependencies.sh
@@ -53,7 +53,7 @@ source "$DIR/setup.cfg"
 echo "Installing the dependencies for AWS deployment"
 
 # ========== Get loader ==========
-server_exec "git clone --depth=1 --branch=$LOADER_BRANCH https://github.com/vhive-serverless/invitro.git loader"
+server_exec "git clone --depth=1 --branch=$LOADER_BRANCH $LOADER_REPO loader"
 echo "Installed the Github repository for the loader"
 
 # ========== Install AWS CLI ==========

--- a/scripts/setup/setup.cfg
+++ b/scripts/setup/setup.cfg
@@ -1,4 +1,6 @@
+VHIVE_REPO='https://github.com/vhive-serverless/vhive'
 VHIVE_BRANCH='v1.7.1'
+LOADER_REPO='https://github.com/vhive-serverless/invitro'
 LOADER_BRANCH='main'
 CLUSTER_MODE='container' # choose from {container, firecracker, firecracker_snapshots}
 PODS_PER_NODE=240


### PR DESCRIPTION
## Summary

Adds a separate variable for `VHIVE_REPO` and `LOADER_REPO` in `./scripts/setup/setup.cfg` to be able to use private repos in setup script (fixes vhive-serverless/invitro#538).

## Implementation Notes :hammer_and_pick:

* Briefly outline the overall technical solution. If necessary, identify talking points where the reviewer's attention should be drawn to.

In scripts under setup directory, next to every `VHIVE_BRANCH` and `LOADER_BRANCH`, repository urls are replaced with a proper variable which has already defined in `setup.cfg`. 

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A
