### PR TITLE
Disable AWS tests

### DIFF
--- a/.github/workflows/e2e_aws.yaml
+++ b/.github/workflows/e2e_aws.yaml
@@ -2,8 +2,6 @@ name: End-to-End AWS Tests
 
 on:
  workflow_dispatch:
- push:
-   branches: [main]
 
 env:
   GOOS: linux


### PR DESCRIPTION
## Summary

Disable the AWS e2e tests on each push to main; tests are still broken.

## Implementation Notes :hammer_and_pick:

* Serverless.com is now a paid service with some free tier available. Requires proper consideration to re-enable.

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A
