### PR TITLE
add loader dry run

### DIFF
--- a/docs/loader.md
+++ b/docs/loader.md
@@ -119,6 +119,8 @@ $ go run cmd/loader.go --config cmd/config_knative_trace.json
 
 Additionally, one can specify log verbosity argument as `--verbosity [info, debug, trace]`. The default value is `info`.
 
+To execute in a dry run mode without generating any load, set the `--dry-run` flag to `true`. This is useful for testing and validating configurations without executing actual requests.
+
 For to configure the workload for load generator, please refer to `docs/configuration.md`.
 
 There are a couple of constants that should not be exposed to the users. They can be examined and changed

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -97,3 +97,11 @@ const (
 	AwsRegion                  = "us-east-1"
 	AwsTraceFuncRepositoryName = "invitro_trace_function_aws"
 )
+
+// CPULimits
+const (
+	CPULimit1vCPU string = "1vCPU"
+	CPULimitGCP   string = "GCP"
+)
+
+var ValidCPULimits = []string{CPULimit1vCPU, CPULimitGCP}

--- a/pkg/common/validators.go
+++ b/pkg/common/validators.go
@@ -1,0 +1,12 @@
+package common
+
+import (
+	"log"
+	"slices"
+)
+
+func CheckCPULimit(cpuLimit string) {
+	if !slices.Contains(ValidCPULimits, cpuLimit) {
+		log.Fatal("Invalid CPU Limit ", cpuLimit)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a dry run flag to the loader, enabling users to execute the loader without generating trace loads or running experiments. Also adds a simple validation for cpu limit field in loader config.

## Implementation Notes :hammer_and_pick:

* Add a dryRun flag to the loader which accepts a boolean value.
* Modifies the execution flow to exit early by checking the dryRun flag just before calling RunExperiment via the experiment driver in the runTraceMode function
* Add a simple validation to ensure provided cpu limit in loader config is valid

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A

*Simply specify none (N/A) if not applicable.*
