### PR TITLE
Correctly enable failure generation

### DIFF
--- a/pkg/driver/failure/triggers.go
+++ b/pkg/driver/failure/triggers.go
@@ -1,12 +1,13 @@
 package failure
 
 import (
-	"github.com/sirupsen/logrus"
-	"github.com/vhive-serverless/loader/pkg/config"
 	"os/exec"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/vhive-serverless/loader/pkg/config"
 )
 
 const (
@@ -18,7 +19,7 @@ const (
 )
 
 func ScheduleFailure(platform string, config *config.FailureConfiguration) {
-	if config != nil && config.FailAt != 0 && config.FailComponent != "" {
+	if config != nil && config.FailureEnabled && config.FailAt != 0 && config.FailComponent != "" {
 		time.Sleep(time.Duration(config.FailAt) * time.Second)
 
 		switch platform {


### PR DESCRIPTION
## Summary

In previous version, the default failure config was triggering failure even when FailureEnabled was set to false

## Implementation Notes :hammer_and_pick:

* Check for the enabled flag before triggering the failure

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A
