### PR TITLE
Extract RPS knob from Platform setting

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -62,7 +62,7 @@ jobs:
         run: go run cmd/loader.go --config pkg/config/test_config.json
 
       - name: Check the output
-        run: test -f "data/out/experiment_duration_5.csv" && test $(grep true data/out/experiment_duration_5.csv | wc -l) -eq 0 # test the output file for errors (true means failure to invoke)
+        run: test -f "data/out/experiment_duration_5.csv" && test $(cat data/out/experiment_duration_5.csv | wc -l) -gt 1 && test $(grep true data/out/experiment_duration_5.csv | wc -l) -eq 0 # test the output file for errors (true means failure to invoke)
 
       - name: Print logs
         if: ${{ always() }}

--- a/.github/workflows/e2e_aws.yaml
+++ b/.github/workflows/e2e_aws.yaml
@@ -60,4 +60,4 @@ jobs:
         run: go run cmd/loader.go --config pkg/config/test_config_aws.json
 
       - name: Check the output
-        run: test -f "data/out/experiment_duration_5.csv" && test $(grep true data/out/experiment_duration_5.csv | wc -l) -eq 0 # test the output file for errors (true means failure to invoke)
+        run: test -f "data/out/experiment_duration_5.csv" && test $(cat data/out/experiment_duration_5.csv | wc -l) -gt 1 && test $(grep true data/out/experiment_duration_5.csv | wc -l) -eq 0 # test the output file for errors (true means failure to invoke)

--- a/cmd/config_dirigent_dandelion_rps.json
+++ b/cmd/config_dirigent_dandelion_rps.json
@@ -1,7 +1,7 @@
 {
   "Seed": 42,
 
-  "Platform": "Dirigent-Dandelion-RPS",
+  "Platform": "Dirigent-Dandelion",
   "InvokeProtocol" : "http1",
   "EndpointPort": 80,
 
@@ -20,7 +20,7 @@
   "RpsMemoryMB": 2048,
   "RpsIterationMultiplier": 80,
 
-  "TracePath": "data/traces/example",
+  "TracePath": "RPS",
   "Granularity": "minute",
   "OutputPathPrefix": "data/out/experiment",
   "IATDistribution": "equidistant",

--- a/cmd/config_dirigent_rps.json
+++ b/cmd/config_dirigent_rps.json
@@ -1,7 +1,7 @@
 {
   "Seed": 42,
 
-  "Platform": "Dirigent-RPS",
+  "Platform": "Dirigent",
   "InvokeProtocol" : "http2",
   "EndpointPort": 80,
 
@@ -20,7 +20,7 @@
   "RpsMemoryMB": 2048,
   "RpsIterationMultiplier": 80,
 
-  "TracePath": "data/traces/example",
+  "TracePath": "RPS",
   "Granularity": "minute",
   "OutputPathPrefix": "data/out/experiment",
   "IATDistribution": "equidistant",

--- a/cmd/config_knative_rps.json
+++ b/cmd/config_knative_rps.json
@@ -1,7 +1,7 @@
 {
   "Seed": 42,
 
-  "Platform": "Knative-RPS",
+  "Platform": "Knative",
   "InvokeProtocol" : "grpc",
   "YAMLSelector": "container",
   "EndpointPort": 80,
@@ -16,7 +16,7 @@
   "RpsMemoryMB": 2048,
   "RpsIterationMultiplier": 80,
 
-  "TracePath": "data/traces/example",
+  "TracePath": "RPS",
   "Granularity": "minute",
   "OutputPathPrefix": "data/out/experiment",
   "IATDistribution": "equidistant",

--- a/cmd/loader.go
+++ b/cmd/loader.go
@@ -28,7 +28,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/vhive-serverless/loader/pkg/generator"
@@ -93,14 +92,9 @@ func main() {
 
 	supportedPlatforms := []string{
 		"Knative",
-		"Knative-RPS",
 		"OpenWhisk",
-		"OpenWhisk-RPS",
 		"AWSLambda",
-		"AWSLambda-RPS",
 		"Dirigent",
-		"Dirigent-RPS",
-		"Dirigent-Dandelion-RPS",
 		"Dirigent-Dandelion",
 	}
 
@@ -108,14 +102,14 @@ func main() {
 		log.Fatal("Unsupported platform!")
 	}
 
-	if cfg.Platform == "Knative" || cfg.Platform == "Knative-RPS" {
+	if cfg.Platform == "Knative" {
 		common.CheckCPULimit(cfg.CPULimit)
 	}
 
-	if !strings.HasSuffix(cfg.Platform, "-RPS") {
-		runTraceMode(&cfg, *iatFromFile, *iatGeneration)
-	} else {
+	if cfg.TracePath == "RPS" {
 		runRPSMode(&cfg, *iatFromFile, *iatGeneration)
+	} else {
+		runTraceMode(&cfg, *iatFromFile, *iatGeneration)
 	}
 }
 
@@ -157,7 +151,7 @@ func parseYAMLSpecification(cfg *config.LoaderConfiguration) string {
 	case "firecracker":
 		return "workloads/firecracker/trace_func_go.yaml"
 	default:
-		if cfg.Platform != "Dirigent" && cfg.Platform != "Dirigent-RPS" && cfg.Platform != "Dirigent-Dandelion-RPS" && cfg.Platform != "Dirigent-Dandelion" {
+		if cfg.Platform != "Dirigent" && cfg.Platform != "Dirigent-Dandelion" {
 			log.Fatal("Invalid 'YAMLSelector' parameter.")
 		}
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,7 +3,7 @@
 | Parameter name               | Data type | Possible values                                                     | Default value       | Description                                                                          |
 |------------------------------|-----------|---------------------------------------------------------------------|---------------------|--------------------------------------------------------------------------------------|
 | Seed                         | int64     | any                                                                 | 42                  | Seed for specification generator (for reproducibility)                               |
-| Platform [^1]                | string    | Knative, OpenWhisk, AWSLambda, Dirigent, Dirigent-Dandelion         | Knative             | The serverless platform the functions will be executed on                            |
+| Platform                     | string    | Knative, OpenWhisk, AWSLambda, Dirigent, Dirigent-Dandelion         | Knative             | The serverless platform the functions will be executed on                            |
 | InvokeProtocol               | string    | grpc, http1, http2                                                  | N/A                 | Protocol to use to communicate with the sandbox                                      |
 | YAMLSelector                 | string    | wimpy, container, firecracker                                       | container           | Service YAML depending on sandbox type                                               |
 | EndpointPort                 | int       | > 0                                                                 | 80                  | Port to be appended to the service URL                                               |
@@ -19,7 +19,7 @@
 | RpsRuntimeMs                 | int       | >=0                                                                 | 0                   | Requested execution time                                                             |
 | RpsMemoryMB                  | int       | >=0                                                                 | 0                   | Requested memory                                                                     |
 | RpsIterationMultiplier       | int       | >=0                                                                 | 0                   | Iteration multiplier for RPS mode                                                    |
-| TracePath                    | string    | string                                                              | data/traces         | Folder with Azure trace dimensions (invocations.csv, durations.csv, memory.csv)      |
+| TracePath [^1]               | string    | string                                                              | data/traces/example | Folder with Azure trace dimensions (invocations.csv, durations.csv, memory.csv) or "RPS" |
 | Granularity                  | string    | minute, second                                                      | minute              | Granularity for trace interpretation[^2]                                             |
 | OutputPathPrefix             | string    | any                                                                 | data/out/experiment | Results file(s) output path prefix                                                   |
 | IATDistribution              | string    | exponential, exponential_shift, uniform, uniform_shift, equidistant | exponential         | IAT distribution[^3]                                                                 |
@@ -38,7 +38,7 @@
 | Width                        | int       | > 0                                                                 | 2                   | Default width of DAG                                                                 |
 | Depth                        | int       | > 0                                                                 | 2                   | Default depth of DAG                                                                 |
 
-[^1]: To run RPS experiments add suffix `-RPS`.
+[^1]: To run RPS experiments replace the path with `RPS`.
 
 [^2]: The second granularity feature interprets each column of the trace as a second, rather than as a minute, and
 generates IAT for each second. This feature is useful for fine-grained and precise invocation scheduling in experiments

--- a/pkg/driver/clients/invoker.go
+++ b/pkg/driver/clients/invoker.go
@@ -1,11 +1,12 @@
 package clients
 
 import (
+	"sync"
+
 	"github.com/sirupsen/logrus"
 	"github.com/vhive-serverless/loader/pkg/common"
 	"github.com/vhive-serverless/loader/pkg/config"
 	"github.com/vhive-serverless/loader/pkg/metric"
-	"sync"
 )
 
 type Invoker interface {
@@ -14,23 +15,23 @@ type Invoker interface {
 
 func CreateInvoker(cfg *config.LoaderConfiguration, announceDoneExe *sync.WaitGroup, readOpenWhiskMetadata *sync.Mutex) Invoker {
 	switch cfg.Platform {
-	case "AWSLambda", "AWSLambda-RPS":
+	case "AWSLambda":
 		return newAWSLambdaInvoker(announceDoneExe)
-	case "Dirigent", "Dirigent-RPS":
+	case "Dirigent":
 		if cfg.InvokeProtocol == "grpc" {
 			return newGRPCInvoker(cfg)
 		} else {
 			return newHTTPInvoker(cfg)
 		}
-	case "Dirigent-Dandelion", "Dirigent-Dandelion-RPS":
+	case "Dirigent-Dandelion":
 		return newHTTPInvoker(cfg)
-	case "Knative", "Knative-RPS":
+	case "Knative":
 		if cfg.InvokeProtocol == "grpc" {
 			return newGRPCInvoker(cfg)
 		} else {
 			return newHTTPInvoker(cfg)
 		}
-	case "OpenWhisk", "OpenWhisk-RPS":
+	case "OpenWhisk":
 		return newOpenWhiskInvoker(announceDoneExe, readOpenWhiskMetadata)
 	default:
 		logrus.Fatal("Unsupported platform.")

--- a/pkg/driver/deployment/deployer.go
+++ b/pkg/driver/deployment/deployer.go
@@ -12,13 +12,13 @@ type FunctionDeployer interface {
 
 func CreateDeployer(cfg *config.Configuration) FunctionDeployer {
 	switch cfg.LoaderConfiguration.Platform {
-	case "AWSLambda", "AWSLambda-RPS":
+	case "AWSLambda":
 		return newAWSLambdaDeployer()
-	case "Dirigent", "Dirigent-RPS", "Dirigent-Dandelion", "Dirigent-Dandelion-RPS":
+	case "Dirigent", "Dirigent-Dandelion":
 		return newDirigentDeployer()
-	case "Knative", "Knative-RPS":
+	case "Knative":
 		return newKnativeDeployer()
-	case "OpenWhisk", "OpenWhisk-RPS":
+	case "OpenWhisk":
 		return newOpenWhiskDeployer()
 	default:
 		logrus.Fatal("Unsupported platform.")

--- a/pkg/driver/failure/triggers.go
+++ b/pkg/driver/failure/triggers.go
@@ -23,9 +23,9 @@ func ScheduleFailure(platform string, config *config.FailureConfiguration) {
 		time.Sleep(time.Duration(config.FailAt) * time.Second)
 
 		switch platform {
-		case "Knative", "Knative-RPS":
+		case "Knative":
 			triggerKnativeFailure(config.FailNode, config.FailComponent)
-		case "Dirigent", "Dirigent-RPS":
+		case "Dirigent":
 			triggerDirigentFailure(config.FailNode, config.FailComponent)
 		default:
 			logrus.Errorf("No specified failure handler for given type of system.")


### PR DESCRIPTION
## Summary

Fixes #536. Extracts the RPS option from Platform. 

## Implementation Notes :hammer_and_pick:

* Create a special value for the trace selector (`RPS`). This would work because we can use either trace path or RPS mode, but not both.

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* Changes the Platform and TracePath configuration parameters.

