### PR TITLE
Remove --concurrency-target Flag from knative.sh

### DIFF
--- a/pkg/driver/deployment/knative.sh
+++ b/pkg/driver/deployment/knative.sh
@@ -14,4 +14,4 @@ export AUTOSCALING_TARGET=${10}
 
 export COLD_START_BUSY_LOOP_MS=${11}
 
-cat $CONFIG_FILE | envsubst | kn service apply $FUNC_NAME --scale-init $INIT_SCALE --concurrency-target 1 --wait-timeout 2000000 -f /dev/stdin
+cat $CONFIG_FILE | envsubst | kn service apply $FUNC_NAME --scale-init $INIT_SCALE --wait-timeout 2000000 -f /dev/stdin


### PR DESCRIPTION
Summary
Removing the --concurrency-target flag from the knative.sh script as it conflicts with the containerConcurrency setting defined in trace_func_go.yaml. Since containerConcurrency specifies a hard limit, adding a soft limit via --concurrency-target=1 can lead to unexpected behaviour when containerConcurrency > 1.

Details 
Hard Limit: Configured via containerConcurrency, strictly enforces the maximum concurrent requests per container.
Soft Limit: Configured via --concurrency-target or autoscaling.knative.dev/target, is a guideline that can be exceeded.
When both limits exist, the smaller value takes precedence. Removing the redundant soft limit avoids conflicts and ensures predictable scaling behaviour.

More information provided in Knative documentation: https://knative.dev/docs/serving/autoscaling/concurrency/