### PR TITLE
Enable Admin API for prometheus

### DIFF
--- a/config/prometh_values_kn.yaml
+++ b/config/prometh_values_kn.yaml
@@ -170,3 +170,4 @@ prometheus:
         memory: 10Gi
       requests:
         memory: 150Mi
+    enableAdminAPI: true


### PR DESCRIPTION
## Summary

Set enableAdminAPI to true to enable administrative HTTP API for Prometheus. Without this administrative endpoints like `/-/snapshot` will not be available, preventing you from generating a snapshot of the TSDB data. Other endpoints, such as `/-/reload` and `/-/quit`, will also be inaccessible.

## Implementation Notes :hammer_and_pick:

- set `enableAdminAPI` to` true` in `config/prometh_values_kn.yaml` under `prometheusSpec`

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A
