### PR TITLE
Change to passthrough resolver

### DIFF
--- a/pkg/driver/clients/grpc_client.go
+++ b/pkg/driver/clients/grpc_client.go
@@ -146,7 +146,7 @@ func (i *grpcInvoker) Invoke(function *common.Function, runtimeSpec *common.Runt
 
 	grpcStart := time.Now()
 
-	conn, err := grpc.NewClient(function.Endpoint, dialOptions...)
+	conn, err := grpc.NewClient("passthrough:///" + function.Endpoint, dialOptions...)
 	if err != nil {
 		logrus.Debugf("Failed to establish a gRPC connection - %v\n", err)
 


### PR DESCRIPTION
Title: Fix high warm start delay by using passthrough resolver

This PR addresses issue #586 where we're experiencing high warm start delays (~50ms) with gRPC connections, particularly at low RPS rates (1 RPS).

When using `grpc.NewClient()` with just the endpoint, it defaults to DNS resolution which adds significant latency to the first connection. This behavior differs from the older `grpc.Dial()` method which defaulted to passthrough resolution.

Solution:
The fix is to explicitly use the passthrough resolver by prefixing the endpoint with "passthrough:///". This bypasses DNS resolution and sends the endpoint string verbatim to the dialer, which significantly reduces connection establishment time.

This change is based on the discussion in grpc/grpc-go#1786 which explains the differences between Dial and NewClient behaviors regarding resolvers.
