### PR TITLE
Refactor Loader.go, in preparation for adding new trace type.

### DIFF
--- a/cmd/loader.go
+++ b/cmd/loader.go
@@ -144,6 +144,7 @@ func parseIATDistribution(cfg *config.LoaderConfiguration) (common.IatDistributi
 	return common.Exponential, false
 }
 
+// Return YAML for "container" or "firecracker microVM"
 func parseYAMLSpecification(cfg *config.LoaderConfiguration) string {
 	switch cfg.YAMLSelector {
 	case "container":
@@ -270,6 +271,9 @@ func runRPSMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIATs
 }
 
 func runMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIATsToFile bool) {
+	//
+	// Determine type of input.
+	//
 	var traceInputType string
 	if cfg.TracePath == "RPS" {
 		traceInputType = "RPS"
@@ -278,9 +282,11 @@ func runMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIATsToF
 	} else { // Reduant, for future input types.
 		log.Fatal("Unsupported Trace Input Type", traceInputType)
 	}
+	log.Info("Detected Trace Input Type", traceInputType)
+
 
 	//
-	// Generate common.Functions
+	// Generate common.Functions + FunctionSpecification (Function's deployment and invocation info)
 	//
 	var functions []*common.Function
 	switch traceInputType {
@@ -288,8 +294,23 @@ func runMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIATsToF
 		functions = RPSGenerateFunctions(cfg)
 	case "Azure2019":
 		functions = Azure2019GenerateFunctions(cfg)
-	default:
-		log.Fatal("Unsupported Trace Input Type:", traceInputType)
+	}
+
+	//
+	// Handle Dirgient (Container orchestrator)
+	//
+	dirigentConfig := config.ReadDirigentConfig(cfg)
+	switch traceInputType {
+	case "RPS":
+		// Handle dirigent metadata, handle warm and cold function differently.
+		functions = generator.AppendDirigentMetadata(cfg, dirigentConfig, functions)
+	case "Azure2019":
+		// Reads Dirigent trace meta-data, and places into *common.Function as property "dirigentMetadata"
+		// Or if Knative yaml is provided, converts it to dirigent configurations. 
+		// Dirigent metadata parsing
+		yamlPath := parseYAMLSpecification(cfg)
+		dirigentMetadataParser := trace.NewDirigentMetadataParser(cfg.TracePath, functions, yamlPath, cfg.Platform)
+		dirigentMetadataParser.Parse()
 	}
 
 	log.Infof("Traces contain the following %d functions:\n", len(functions))
@@ -299,9 +320,8 @@ func runMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIATsToF
 
 	driver.ReadOrWriteSpecificationToFile(functions, writeIATsToFile, readIATFromFile)
 
-	experimentDuration := determineDurationToParse(cfg.ExperimentDuration, cfg.WarmupDuration)
-	dirigentConfig := config.ReadDirigentConfig(cfg)
 
+	experimentDuration := determineDurationToParse(cfg.ExperimentDuration, cfg.WarmupDuration)
 	experimentDriver := driver.NewDriver(&config.Configuration{
 		LoaderConfiguration:   cfg,
 		TraceDuration:         experimentDuration,
@@ -330,10 +350,11 @@ func RPSGenerateFunctions(cfg *config.LoaderConfiguration) []*common.Function {
 	warmFunction, warmStartCount := generator.GenerateWarmStartFunction(experimentDuration, warmStartRPS)
 	coldFunctions, coldStartCount := generator.GenerateColdStartFunctions(experimentDuration, coldStartRPS, cfg.RpsCooldownSeconds)
 
-	// loads dirigent config only if the platform is 'dirigent'
-	dirigentConfig := config.ReadDirigentConfig(cfg)
+	functions := generator.CreateRPSFunctions(cfg, warmFunction, warmStartCount, coldFunctions, coldStartCount, yamlPath)
 
-	functions := generator.CreateRPSFunctions(cfg, dirigentConfig, warmFunction, warmStartCount, coldFunctions, coldStartCount, yamlPath)
+	// Handle dirigent metadata, handle warm and cold function differently.
+	// dirigentConfig := config.ReadDirigentConfig(cfg)
+	// functions = generator.AppendDirigentMetadata(cfg, dirigentConfig, functions)
 
 	return functions
 }
@@ -350,16 +371,7 @@ func Azure2019GenerateFunctions(cfg *config.LoaderConfiguration) []*common.Funct
 	} else {
 		traceParser = trace.NewMapperParser(cfg.TracePath, durationToParse)
 	}
-
 	functions = traceParser.Parse()
-	// Dirigent metadata parsing
-	dirigentMetadataParser := trace.NewDirigentMetadataParser(cfg.TracePath, functions, yamlPath, cfg.Platform)
-	dirigentMetadataParser.Parse()
-
-	log.Infof("Traces contain the following %d functions:\n", len(functions))
-	for _, function := range functions {
-		fmt.Printf("\t%s\n", function.Name)
-	}
 
 	iatType, shiftIAT := parseIATDistribution(cfg)
 	traceGranularity := parseTraceGranularity(cfg)

--- a/cmd/loader.go
+++ b/cmd/loader.go
@@ -227,8 +227,12 @@ func runMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIATsToF
 	experimentDriver := driver.NewDriver(&config.Configuration{
 		LoaderConfiguration:   cfg,
 		FailureConfiguration: config.ReadFailureConfiguration(*failurePath),
-		TraceDuration:         experimentDuration,
 		DirigentConfiguration: dirigentConfig,
+
+		TraceGranularity: parseTraceGranularity(cfg),
+		TestMode: false,
+
+		TraceDuration:         experimentDuration,
 		Functions:             functions,
 	})
 

--- a/cmd/loader.go
+++ b/cmd/loader.go
@@ -106,11 +106,6 @@ func main() {
 	}
 
 	runMode(&cfg, *iatFromFile, *iatGeneration)
-	// if cfg.TracePath == "RPS" {
-	// 	runRPSMode(&cfg, *iatFromFile, *iatGeneration)
-	// } else {
-	// 	runTraceMode(&cfg, *iatFromFile, *iatGeneration)
-	// }
 }
 
 func determineDurationToParse(runtimeDuration int, warmupDuration int) int {
@@ -210,7 +205,7 @@ func runMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIATsToF
 	switch traceInputType {
 	case "RPS":
 		// Handle dirigent metadata, handle warm and cold function differently.
-		functions = generator.AppendDirigentMetadata(cfg, dirigentConfig, functions)
+		generator.AppendDirigentMetadata(functions, cfg, dirigentConfig)
 	case "Azure2019", "vSwarm":
 		// Reads Dirigent trace meta-data, and places into *common.Function as property "dirigentMetadata"
 		// Or if Knative yaml is provided, converts it to dirigent configurations. 
@@ -280,7 +275,7 @@ func Azure2019GenerateFunctions(cfg *config.LoaderConfiguration) []*common.Funct
 
 	iatType, shiftIAT := parseIATDistribution(cfg)
 	traceGranularity := parseTraceGranularity(cfg)
-	functions = driver.GenerateAzure2019Specification(functions, cfg, iatType, shiftIAT, traceGranularity)
+	generator.GenerateAzure2019Specification(functions, cfg, iatType, shiftIAT, traceGranularity)
 
 	return functions
 }

--- a/cmd/loader.go
+++ b/cmd/loader.go
@@ -195,6 +195,10 @@ func runTraceMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIA
 	}
 
 	iatType, shiftIAT := parseIATDistribution(cfg)
+	traceGranularity := parseTraceGranularity(cfg)
+	functions = driver.GenerateAzure2019Specification(functions, cfg, iatType, shiftIAT, traceGranularity)
+
+	driver.ReadOrWriteSpecificationToFile(functions, writeIATsToFile, readIATFromFile)
 
 	experimentDriver := driver.NewDriver(&config.Configuration{
 		LoaderConfiguration:  cfg,
@@ -203,10 +207,11 @@ func runTraceMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIA
 		// loads dirigent config only if the platform is 'dirigent'
 		DirigentConfiguration: config.ReadDirigentConfig(cfg),
 
-		IATDistribution:  iatType,
-		ShiftIAT:         shiftIAT,
-		TraceGranularity: parseTraceGranularity(cfg),
-		TraceDuration:    durationToParse,
+		// IATDistribution:  iatType,
+		// ShiftIAT:         shiftIAT,
+		// TraceGranularity: traceGranularity,
+
+		TraceDuration: durationToParse,
 
 		TestMode: false,
 
@@ -220,8 +225,8 @@ func runTraceMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIA
 
 	log.Infof("Using %s as a service YAML specification file.\n", yamlPath)
 
-	experimentDriver.GenerateSpecification()
-	experimentDriver.ReadOrWriteFileSpecification(writeIATsToFile, readIATFromFile)
+	//experimentDriver.GenerateSpecification()
+	//experimentDriver.ReadOrWriteFileSpecification(writeIATsToFile, readIATFromFile)
 	experimentDriver.RunExperiment()
 }
 
@@ -241,13 +246,17 @@ func runRPSMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIATs
 	// loads dirigent config only if the platform is 'dirigent'
 	dirigentConfig := config.ReadDirigentConfig(cfg)
 
+	functions := generator.CreateRPSFunctions(cfg, dirigentConfig, warmFunction, warmStartCount, coldFunctions, coldStartCount, yamlPath)
+
+	driver.ReadOrWriteSpecificationToFile(functions, writeIATsToFile, readIATFromFile)
+
 	experimentDriver := driver.NewDriver(&config.Configuration{
 		LoaderConfiguration: cfg,
 		TraceDuration:       experimentDuration,
 
 		DirigentConfiguration: dirigentConfig,
 
-		Functions: generator.CreateRPSFunctions(cfg, dirigentConfig, warmFunction, warmStartCount, coldFunctions, coldStartCount, yamlPath),
+		Functions: functions,
 	})
 
 	// Skip experiments execution during dry run mode
@@ -255,6 +264,6 @@ func runRPSMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIATs
 		return
 	}
 
-	experimentDriver.ReadOrWriteFileSpecification(writeIATsToFile, readIATFromFile)
+	//experimentDriver.ReadOrWriteFileSpecification(writeIATsToFile, readIATFromFile)
 	experimentDriver.RunExperiment()
 }

--- a/cmd/loader.go
+++ b/cmd/loader.go
@@ -173,103 +173,6 @@ func parseTraceGranularity(cfg *config.LoaderConfiguration) common.TraceGranular
 	return common.MinuteGranularity
 }
 
-func runTraceMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIATsToFile bool) {
-	durationToParse := determineDurationToParse(cfg.ExperimentDuration, cfg.WarmupDuration)
-	yamlPath := parseYAMLSpecification(cfg)
-	var functions []*common.Function
-	var traceParser trace.Parser
-
-	// Azure trace parsing
-	if !cfg.VSwarm {
-		traceParser = trace.NewAzureParser(cfg.TracePath, durationToParse, yamlPath)
-	} else {
-		traceParser = trace.NewMapperParser(cfg.TracePath, durationToParse)
-	}
-
-	functions = traceParser.Parse()
-	// Dirigent metadata parsing
-	dirigentMetadataParser := trace.NewDirigentMetadataParser(cfg.TracePath, functions, yamlPath, cfg.Platform)
-	dirigentMetadataParser.Parse()
-
-	log.Infof("Traces contain the following %d functions:\n", len(functions))
-	for _, function := range functions {
-		fmt.Printf("\t%s\n", function.Name)
-	}
-
-	iatType, shiftIAT := parseIATDistribution(cfg)
-	traceGranularity := parseTraceGranularity(cfg)
-	functions = driver.GenerateAzure2019Specification(functions, cfg, iatType, shiftIAT, traceGranularity)
-
-	driver.ReadOrWriteSpecificationToFile(functions, writeIATsToFile, readIATFromFile)
-
-	experimentDriver := driver.NewDriver(&config.Configuration{
-		LoaderConfiguration:  cfg,
-		FailureConfiguration: config.ReadFailureConfiguration(*failurePath),
-
-		// loads dirigent config only if the platform is 'dirigent'
-		DirigentConfiguration: config.ReadDirigentConfig(cfg),
-
-		// IATDistribution:  iatType,
-		// ShiftIAT:         shiftIAT,
-		// TraceGranularity: traceGranularity,
-
-		TraceDuration: durationToParse,
-
-		TestMode: false,
-
-		Functions: functions,
-	})
-
-	// Skip experiments execution during dry run mode
-	if *dryRun {
-		return
-	}
-
-	log.Infof("Using %s as a service YAML specification file.\n", yamlPath)
-
-	//experimentDriver.GenerateSpecification()
-	//experimentDriver.ReadOrWriteFileSpecification(writeIATsToFile, readIATFromFile)
-	experimentDriver.RunExperiment()
-}
-
-func runRPSMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIATsToFile bool) {
-	experimentDuration := determineDurationToParse(cfg.ExperimentDuration, cfg.WarmupDuration)
-	yamlPath := parseYAMLSpecification(cfg)
-
-	rpsTarget := cfg.RpsTarget
-	coldStartPercentage := cfg.RpsColdStartRatioPercentage
-
-	warmStartRPS := rpsTarget * (100 - coldStartPercentage) / 100
-	coldStartRPS := rpsTarget * coldStartPercentage / 100
-
-	warmFunction, warmStartCount := generator.GenerateWarmStartFunction(experimentDuration, warmStartRPS)
-	coldFunctions, coldStartCount := generator.GenerateColdStartFunctions(experimentDuration, coldStartRPS, cfg.RpsCooldownSeconds)
-
-	// loads dirigent config only if the platform is 'dirigent'
-	dirigentConfig := config.ReadDirigentConfig(cfg)
-
-	functions := generator.CreateRPSFunctions(cfg, warmFunction, warmStartCount, coldFunctions, coldStartCount, yamlPath)
-
-	driver.ReadOrWriteSpecificationToFile(functions, writeIATsToFile, readIATFromFile)
-
-	experimentDriver := driver.NewDriver(&config.Configuration{
-		LoaderConfiguration: cfg,
-		TraceDuration:       experimentDuration,
-
-		DirigentConfiguration: dirigentConfig,
-
-		Functions: functions,
-	})
-
-	// Skip experiments execution during dry run mode
-	if *dryRun {
-		return
-	}
-
-	//experimentDriver.ReadOrWriteFileSpecification(writeIATsToFile, readIATFromFile)
-	experimentDriver.RunExperiment()
-}
-
 func runMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIATsToFile bool) {
 	//
 	// Determine type of input.
@@ -328,6 +231,7 @@ func runMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIATsToF
 	experimentDuration := determineDurationToParse(cfg.ExperimentDuration, cfg.WarmupDuration)
 	experimentDriver := driver.NewDriver(&config.Configuration{
 		LoaderConfiguration:   cfg,
+		FailureConfiguration: config.ReadFailureConfiguration(*failurePath),
 		TraceDuration:         experimentDuration,
 		DirigentConfiguration: dirigentConfig,
 		Functions:             functions,

--- a/cmd/loader.go
+++ b/cmd/loader.go
@@ -248,7 +248,7 @@ func runRPSMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIATs
 	// loads dirigent config only if the platform is 'dirigent'
 	dirigentConfig := config.ReadDirigentConfig(cfg)
 
-	functions := generator.CreateRPSFunctions(cfg, dirigentConfig, warmFunction, warmStartCount, coldFunctions, coldStartCount, yamlPath)
+	functions := generator.CreateRPSFunctions(cfg, warmFunction, warmStartCount, coldFunctions, coldStartCount, yamlPath)
 
 	driver.ReadOrWriteSpecificationToFile(functions, writeIATsToFile, readIATFromFile)
 
@@ -277,13 +277,17 @@ func runMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIATsToF
 	var traceInputType string
 	if cfg.TracePath == "RPS" {
 		traceInputType = "RPS"
-	} else if cfg.TracePath != "RPS" {
-		traceInputType = "Azure2019"
-	} else { // Reduant, for future input types.
-		log.Fatal("Unsupported Trace Input Type", traceInputType)
+	} else { 
+		if cfg.VSwarm {
+			traceInputType = "vSwarm"
+		} else if !cfg.VSwarm {
+			traceInputType = "Azure2019"
+		}
+		// else { // Reduant, for future input types.
+		// 	log.Fatal("Unsupported Trace Input Type", traceInputType)
+		// }
 	}
 	log.Info("Detected Trace Input Type", traceInputType)
-
 
 	//
 	// Generate common.Functions + FunctionSpecification (Function's deployment and invocation info)
@@ -292,7 +296,7 @@ func runMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIATsToF
 	switch traceInputType {
 	case "RPS":
 		functions = RPSGenerateFunctions(cfg)
-	case "Azure2019":
+	case "Azure2019", "vSwarm":
 		functions = Azure2019GenerateFunctions(cfg)
 	}
 
@@ -304,7 +308,7 @@ func runMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIATsToF
 	case "RPS":
 		// Handle dirigent metadata, handle warm and cold function differently.
 		functions = generator.AppendDirigentMetadata(cfg, dirigentConfig, functions)
-	case "Azure2019":
+	case "Azure2019", "vSwarm":
 		// Reads Dirigent trace meta-data, and places into *common.Function as property "dirigentMetadata"
 		// Or if Knative yaml is provided, converts it to dirigent configurations. 
 		// Dirigent metadata parsing
@@ -352,13 +356,10 @@ func RPSGenerateFunctions(cfg *config.LoaderConfiguration) []*common.Function {
 
 	functions := generator.CreateRPSFunctions(cfg, warmFunction, warmStartCount, coldFunctions, coldStartCount, yamlPath)
 
-	// Handle dirigent metadata, handle warm and cold function differently.
-	// dirigentConfig := config.ReadDirigentConfig(cfg)
-	// functions = generator.AppendDirigentMetadata(cfg, dirigentConfig, functions)
-
 	return functions
 }
 
+// TODO: Future development to add Azure2021 trace support.
 func Azure2019GenerateFunctions(cfg *config.LoaderConfiguration) []*common.Function {
 	durationToParse := determineDurationToParse(cfg.ExperimentDuration, cfg.WarmupDuration)
 	yamlPath := parseYAMLSpecification(cfg)

--- a/cmd/loader.go
+++ b/cmd/loader.go
@@ -105,7 +105,7 @@ func main() {
 		common.CheckCPULimit(cfg.CPULimit)
 	}
 
-	runMode(&cfg, *iatFromFile, *iatGeneration)
+	run(&cfg, *iatFromFile, *iatGeneration)
 }
 
 func determineDurationToParse(runtimeDuration int, warmupDuration int) int {
@@ -168,22 +168,21 @@ func parseTraceGranularity(cfg *config.LoaderConfiguration) common.TraceGranular
 	return common.MinuteGranularity
 }
 
-func runMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIATsToFile bool) {
+func run(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIATsToFile bool) {
 	//
 	// Determine type of input.
 	//
 	var traceInputType string
 	if cfg.TracePath == "RPS" {
 		traceInputType = "RPS"
-	} else { 
+	} else {
 		if cfg.VSwarm {
 			traceInputType = "vSwarm"
 		} else if !cfg.VSwarm {
 			traceInputType = "Azure2019"
+		} else { // Reduant, for future input types.
+			log.Fatal("Unsupported Trace Input Type", traceInputType)
 		}
-		// else { // Reduant, for future input types.
-		// 	log.Fatal("Unsupported Trace Input Type", traceInputType)
-		// }
 	}
 	log.Info("Detected Trace Input Type", traceInputType)
 
@@ -200,16 +199,13 @@ func runMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIATsToF
 
 	//
 	// Handle Dirgient (Container orchestrator)
+	// Reads Dirigent trace meta-data, and places into *common.Function as property "dirigentMetadata"
 	//
 	dirigentConfig := config.ReadDirigentConfig(cfg)
 	switch traceInputType {
 	case "RPS":
-		// Handle dirigent metadata, handle warm and cold function differently.
 		generator.AppendDirigentMetadata(functions, cfg, dirigentConfig)
 	case "Azure2019", "vSwarm":
-		// Reads Dirigent trace meta-data, and places into *common.Function as property "dirigentMetadata"
-		// Or if Knative yaml is provided, converts it to dirigent configurations. 
-		// Dirigent metadata parsing
 		yamlPath := parseYAMLSpecification(cfg)
 		dirigentMetadataParser := trace.NewDirigentMetadataParser(cfg.TracePath, functions, yamlPath, cfg.Platform)
 		dirigentMetadataParser.Parse()
@@ -222,18 +218,17 @@ func runMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIATsToF
 
 	driver.ReadOrWriteSpecificationToFile(functions, writeIATsToFile, readIATFromFile)
 
-
 	experimentDuration := determineDurationToParse(cfg.ExperimentDuration, cfg.WarmupDuration)
 	experimentDriver := driver.NewDriver(&config.Configuration{
 		LoaderConfiguration:   cfg,
-		FailureConfiguration: config.ReadFailureConfiguration(*failurePath),
+		FailureConfiguration:  config.ReadFailureConfiguration(*failurePath),
 		DirigentConfiguration: dirigentConfig,
 
 		TraceGranularity: parseTraceGranularity(cfg),
-		TestMode: false,
+		TestMode:         false,
 
-		TraceDuration:         experimentDuration,
-		Functions:             functions,
+		TraceDuration: experimentDuration,
+		Functions:     functions,
 	})
 
 	// Skip experiments execution during dry run mode

--- a/cmd/loader.go
+++ b/cmd/loader.go
@@ -105,11 +105,12 @@ func main() {
 		common.CheckCPULimit(cfg.CPULimit)
 	}
 
-	if cfg.TracePath == "RPS" {
-		runRPSMode(&cfg, *iatFromFile, *iatGeneration)
-	} else {
-		runTraceMode(&cfg, *iatFromFile, *iatGeneration)
-	}
+	runMode(&cfg, *iatFromFile, *iatGeneration)
+	// if cfg.TracePath == "RPS" {
+	// 	runRPSMode(&cfg, *iatFromFile, *iatGeneration)
+	// } else {
+	// 	runTraceMode(&cfg, *iatFromFile, *iatGeneration)
+	// }
 }
 
 func determineDurationToParse(runtimeDuration int, warmupDuration int) int {
@@ -266,4 +267,103 @@ func runRPSMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIATs
 
 	//experimentDriver.ReadOrWriteFileSpecification(writeIATsToFile, readIATFromFile)
 	experimentDriver.RunExperiment()
+}
+
+func runMode(cfg *config.LoaderConfiguration, readIATFromFile bool, writeIATsToFile bool) {
+	var traceInputType string
+	if cfg.TracePath == "RPS" {
+		traceInputType = "RPS"
+	} else if cfg.TracePath != "RPS" {
+		traceInputType = "Azure2019"
+	} else { // Reduant, for future input types.
+		log.Fatal("Unsupported Trace Input Type", traceInputType)
+	}
+
+	//
+	// Generate common.Functions
+	//
+	var functions []*common.Function
+	switch traceInputType {
+	case "RPS":
+		functions = RPSGenerateFunctions(cfg)
+	case "Azure2019":
+		functions = Azure2019GenerateFunctions(cfg)
+	default:
+		log.Fatal("Unsupported Trace Input Type:", traceInputType)
+	}
+
+	log.Infof("Traces contain the following %d functions:\n", len(functions))
+	for _, function := range functions {
+		fmt.Printf("\t%s\n", function.Name)
+	}
+
+	driver.ReadOrWriteSpecificationToFile(functions, writeIATsToFile, readIATFromFile)
+
+	experimentDuration := determineDurationToParse(cfg.ExperimentDuration, cfg.WarmupDuration)
+	dirigentConfig := config.ReadDirigentConfig(cfg)
+
+	experimentDriver := driver.NewDriver(&config.Configuration{
+		LoaderConfiguration:   cfg,
+		TraceDuration:         experimentDuration,
+		DirigentConfiguration: dirigentConfig,
+		Functions:             functions,
+	})
+
+	// Skip experiments execution during dry run mode
+	if *dryRun {
+		return
+	}
+
+	experimentDriver.RunExperiment()
+}
+
+func RPSGenerateFunctions(cfg *config.LoaderConfiguration) []*common.Function {
+	experimentDuration := determineDurationToParse(cfg.ExperimentDuration, cfg.WarmupDuration)
+	yamlPath := parseYAMLSpecification(cfg)
+
+	rpsTarget := cfg.RpsTarget
+	coldStartPercentage := cfg.RpsColdStartRatioPercentage
+
+	warmStartRPS := rpsTarget * (100 - coldStartPercentage) / 100
+	coldStartRPS := rpsTarget * coldStartPercentage / 100
+
+	warmFunction, warmStartCount := generator.GenerateWarmStartFunction(experimentDuration, warmStartRPS)
+	coldFunctions, coldStartCount := generator.GenerateColdStartFunctions(experimentDuration, coldStartRPS, cfg.RpsCooldownSeconds)
+
+	// loads dirigent config only if the platform is 'dirigent'
+	dirigentConfig := config.ReadDirigentConfig(cfg)
+
+	functions := generator.CreateRPSFunctions(cfg, dirigentConfig, warmFunction, warmStartCount, coldFunctions, coldStartCount, yamlPath)
+
+	return functions
+}
+
+func Azure2019GenerateFunctions(cfg *config.LoaderConfiguration) []*common.Function {
+	durationToParse := determineDurationToParse(cfg.ExperimentDuration, cfg.WarmupDuration)
+	yamlPath := parseYAMLSpecification(cfg)
+	var functions []*common.Function
+	var traceParser trace.Parser
+
+	// Azure trace parsing
+	if !cfg.VSwarm {
+		traceParser = trace.NewAzureParser(cfg.TracePath, durationToParse, yamlPath)
+	} else {
+		traceParser = trace.NewMapperParser(cfg.TracePath, durationToParse)
+	}
+
+	functions = traceParser.Parse()
+	// Dirigent metadata parsing
+	dirigentMetadataParser := trace.NewDirigentMetadataParser(cfg.TracePath, functions, yamlPath, cfg.Platform)
+	dirigentMetadataParser.Parse()
+
+	log.Infof("Traces contain the following %d functions:\n", len(functions))
+	for _, function := range functions {
+		fmt.Printf("\t%s\n", function.Name)
+	}
+
+	iatType, shiftIAT := parseIATDistribution(cfg)
+	traceGranularity := parseTraceGranularity(cfg)
+	functions = driver.GenerateAzure2019Specification(functions, cfg, iatType, shiftIAT, traceGranularity)
+
+	return functions
 }

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -9,8 +9,6 @@ type Configuration struct {
 	FailureConfiguration  *FailureConfiguration
 	DirigentConfiguration *DirigentConfig
 
-	IATDistribution  common.IatDistribution
-	ShiftIAT         bool // shift the invocations inside minute
 	TraceGranularity common.TraceGranularity
 	// TraceDuration In minutes.
 	TraceDuration int

--- a/pkg/driver/trace_driver.go
+++ b/pkg/driver/trace_driver.go
@@ -433,6 +433,7 @@ func (d *Driver) internalRun() {
 	log.Infof("Failure rate: \t\t\t%.2f%%", float64(statFailed)*100.0/float64(statSuccess+statFailed))
 }
 
+// DEPRECATED: Use func GenerateAzure2019Specification() in generator package, in specification.go instead
 func (d *Driver) GenerateSpecification() {
 	log.Info("Generating IAT and runtime specifications for all the functions")
 
@@ -452,6 +453,30 @@ func (d *Driver) GenerateSpecification() {
 	}
 }
 
+// Generates IATs and runtime specifications for Azure2019 trace type, returns completed `functions` with Specification filled.
+func GenerateAzure2019Specification(functions []*common.Function, loaderCfg *config.LoaderConfiguration, IATDistribution common.IatDistribution, shiftIAT bool, traceGranularity common.TraceGranularity) []*common.Function {
+	log.Info("Generating IAT and runtime specifications for all the functions")
+
+	azure2019Generator := generator.NewSpecificationGenerator(loaderCfg.Seed)
+
+	for i, function := range functions {
+		// Equalising all the InvocationStats to the first function
+		if loaderCfg.DAGMode {
+			function.InvocationStats.Invocations = functions[0].InvocationStats.Invocations
+		}
+		spec := azure2019Generator.GenerateInvocationData(
+			function,
+			IATDistribution,
+			shiftIAT,
+			traceGranularity,
+		)
+
+		functions[i].Specification = spec
+	}
+	return functions
+}
+
+// DEPRECATED, use ReadOrWriteSpecificationToFile()
 func (d *Driver) outputIATsToFile() {
 	for i, function := range d.Configuration.Functions {
 		file, _ := json.MarshalIndent(function.Specification, "", " ")
@@ -462,6 +487,7 @@ func (d *Driver) outputIATsToFile() {
 	}
 }
 
+// DEPRECATED, use ReadOrWriteSpecificationToFile()
 func (d *Driver) ReadOrWriteFileSpecification(writeIATsToFile bool, readIATsFromFile bool) {
 	if writeIATsToFile && readIATsFromFile {
 		log.Fatal("Invalid loader configuration. No point to read and write IATs within the same run.")
@@ -488,6 +514,46 @@ func (d *Driver) ReadOrWriteFileSpecification(writeIATsToFile bool, readIATsFrom
 		}
 	}
 }
+
+// Writes OR Reads IATs to/from .json files.
+// Performs read or write only if flag set.
+func ReadOrWriteSpecificationToFile(functions []*common.Function, writeIATsToFile bool, readIATsFromFile bool) {
+	if writeIATsToFile && readIATsFromFile {
+		log.Fatal("Invalid loader configuration. No point to read and write IATs within the same run.")
+	}
+
+	if readIATsFromFile {
+		// Parse and read IATs Function Specifications
+		for i := range functions {
+			var spec common.FunctionSpecification
+
+			iatFile, _ := os.ReadFile("iat" + strconv.Itoa(i) + ".json")
+			err := json.Unmarshal(iatFile, &spec)
+			if err != nil {
+				log.Fatalf("Failed to unmarshal IAT file: %s", err)
+			}
+			functions[i].Specification = &spec
+		}
+
+		log.Info("IATs have been read from file(s).")
+	}
+
+	if writeIATsToFile {
+		// Writes IATs Function Specifictions to .jsons file
+		for i, function := range functions {
+			file, _ := json.MarshalIndent(function.Specification, "", " ")
+			err := os.WriteFile("iat"+strconv.Itoa(i)+".json", file, 0644)
+			if err != nil {
+				log.Fatalf("Writing the loader config file failed: %s", err)
+			}
+		}
+
+		log.Info("IATs have been generated.. The program has exited.")
+		os.Exit(0)
+	}
+}
+
+
 
 func (d *Driver) RunExperiment() {
 	if d.Configuration.WithWarmup() {

--- a/pkg/driver/trace_driver.go
+++ b/pkg/driver/trace_driver.go
@@ -433,26 +433,6 @@ func (d *Driver) internalRun() {
 	log.Infof("Failure rate: \t\t\t%.2f%%", float64(statFailed)*100.0/float64(statSuccess+statFailed))
 }
 
-// DEPRECATED: Use func GenerateAzure2019Specification() in generator package, in specification.go instead
-func (d *Driver) GenerateSpecification() {
-	log.Info("Generating IAT and runtime specifications for all the functions")
-
-	for i, function := range d.Configuration.Functions {
-		// Equalising all the InvocationStats to the first function
-		if d.Configuration.LoaderConfiguration.DAGMode {
-			function.InvocationStats.Invocations = d.Configuration.Functions[0].InvocationStats.Invocations
-		}
-		spec := d.SpecificationGenerator.GenerateInvocationData(
-			function,
-			d.Configuration.IATDistribution,
-			d.Configuration.ShiftIAT,
-			d.Configuration.TraceGranularity,
-		)
-
-		d.Configuration.Functions[i].Specification = spec
-	}
-}
-
 // Generates IATs and runtime specifications for Azure2019 trace type, returns completed `functions` with Specification filled.
 func GenerateAzure2019Specification(functions []*common.Function, loaderCfg *config.LoaderConfiguration, IATDistribution common.IatDistribution, shiftIAT bool, traceGranularity common.TraceGranularity) []*common.Function {
 	log.Info("Generating IAT and runtime specifications for all the functions")
@@ -474,45 +454,6 @@ func GenerateAzure2019Specification(functions []*common.Function, loaderCfg *con
 		functions[i].Specification = spec
 	}
 	return functions
-}
-
-// DEPRECATED, use ReadOrWriteSpecificationToFile()
-func (d *Driver) outputIATsToFile() {
-	for i, function := range d.Configuration.Functions {
-		file, _ := json.MarshalIndent(function.Specification, "", " ")
-		err := os.WriteFile("iat"+strconv.Itoa(i)+".json", file, 0644)
-		if err != nil {
-			log.Fatalf("Writing the loader config file failed: %s", err)
-		}
-	}
-}
-
-// DEPRECATED, use ReadOrWriteSpecificationToFile()
-func (d *Driver) ReadOrWriteFileSpecification(writeIATsToFile bool, readIATsFromFile bool) {
-	if writeIATsToFile && readIATsFromFile {
-		log.Fatal("Invalid loader configuration. No point to read and write IATs within the same run.")
-	}
-
-	if writeIATsToFile {
-		d.outputIATsToFile()
-
-		log.Info("IATs have been generated. The program has exited.")
-		os.Exit(0)
-	}
-
-	if readIATsFromFile {
-		for i := range d.Configuration.Functions {
-			var spec common.FunctionSpecification
-
-			iatFile, _ := os.ReadFile("iat" + strconv.Itoa(i) + ".json")
-			err := json.Unmarshal(iatFile, &spec)
-			if err != nil {
-				log.Fatalf("Failed to unmarshal IAT file: %s", err)
-			}
-
-			d.Configuration.Functions[i].Specification = &spec
-		}
-	}
 }
 
 // Writes OR Reads IATs to/from .json files.

--- a/pkg/driver/trace_driver.go
+++ b/pkg/driver/trace_driver.go
@@ -433,29 +433,6 @@ func (d *Driver) internalRun() {
 	log.Infof("Failure rate: \t\t\t%.2f%%", float64(statFailed)*100.0/float64(statSuccess+statFailed))
 }
 
-// Generates IATs and runtime specifications for Azure2019 trace type, returns completed `functions` with Specification filled.
-func GenerateAzure2019Specification(functions []*common.Function, loaderCfg *config.LoaderConfiguration, IATDistribution common.IatDistribution, shiftIAT bool, traceGranularity common.TraceGranularity) []*common.Function {
-	log.Info("Generating IAT and runtime specifications for all the functions")
-
-	azure2019Generator := generator.NewSpecificationGenerator(loaderCfg.Seed)
-
-	for i, function := range functions {
-		// Equalising all the InvocationStats to the first function
-		if loaderCfg.DAGMode {
-			function.InvocationStats.Invocations = functions[0].InvocationStats.Invocations
-		}
-		spec := azure2019Generator.GenerateInvocationData(
-			function,
-			IATDistribution,
-			shiftIAT,
-			traceGranularity,
-		)
-
-		functions[i].Specification = spec
-	}
-	return functions
-}
-
 // Writes OR Reads IATs to/from .json files.
 // Performs read or write only if flag set.
 func ReadOrWriteSpecificationToFile(functions []*common.Function, writeIATsToFile bool, readIATsFromFile bool) {

--- a/pkg/driver/trace_driver_test.go
+++ b/pkg/driver/trace_driver_test.go
@@ -578,7 +578,11 @@ func TestDriverCompletely(t *testing.T) {
 			driver.Configuration.TraceDuration = test.experimentDurationMin
 			driver.Configuration.TraceGranularity = test.traceGranularity
 
-			driver.GenerateSpecification()
+			// Deprecating driver.GenerateSpecification()
+			driver.Configuration.Functions = GenerateAzure2019Specification(
+				driver.Configuration.Functions, driver.Configuration.LoaderConfiguration,
+				driver.Configuration.IATDistribution, driver.Configuration.ShiftIAT, driver.Configuration.TraceGranularity)
+
 			driver.RunExperiment()
 
 			f, err := os.Open(driver.outputFilename("duration"))
@@ -674,7 +678,11 @@ func TestVSwarmDriverCompletely(t *testing.T) {
 			driver.Configuration.TraceDuration = test.experimentDurationMin
 			driver.Configuration.TraceGranularity = test.traceGranularity
 
-			driver.GenerateSpecification()
+			// Deprecating driver.GenerateSpecification()
+			driver.Configuration.Functions = GenerateAzure2019Specification(
+				driver.Configuration.Functions, driver.Configuration.LoaderConfiguration,
+				driver.Configuration.IATDistribution, driver.Configuration.ShiftIAT, driver.Configuration.TraceGranularity)
+
 			driver.RunExperiment()
 
 			f, err := os.Open(driver.outputFilename("duration"))

--- a/pkg/driver/trace_driver_test.go
+++ b/pkg/driver/trace_driver_test.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"github.com/vhive-serverless/loader/pkg/config"
+	"github.com/vhive-serverless/loader/pkg/generator"
 
 	"github.com/gocarina/gocsv"
 	"github.com/sirupsen/logrus"
@@ -579,7 +580,7 @@ func TestDriverCompletely(t *testing.T) {
 			driver.Configuration.TraceGranularity = test.traceGranularity
 
 			// Deprecating driver.GenerateSpecification()
-			driver.Configuration.Functions = GenerateAzure2019Specification(
+			generator.GenerateAzure2019Specification(
 				driver.Configuration.Functions, driver.Configuration.LoaderConfiguration,
 				driver.Configuration.IATDistribution, driver.Configuration.ShiftIAT, driver.Configuration.TraceGranularity)
 
@@ -679,7 +680,7 @@ func TestVSwarmDriverCompletely(t *testing.T) {
 			driver.Configuration.TraceGranularity = test.traceGranularity
 
 			// Deprecating driver.GenerateSpecification()
-			driver.Configuration.Functions = GenerateAzure2019Specification(
+			generator.GenerateAzure2019Specification(
 				driver.Configuration.Functions, driver.Configuration.LoaderConfiguration,
 				driver.Configuration.IATDistribution, driver.Configuration.ShiftIAT, driver.Configuration.TraceGranularity)
 

--- a/pkg/driver/trace_driver_test.go
+++ b/pkg/driver/trace_driver_test.go
@@ -61,7 +61,6 @@ func createTestDriver(invocationStats []int, vSwarm bool) *Driver {
 
 	driver := NewDriver(&config.Configuration{
 		LoaderConfiguration: cfg,
-		IATDistribution:     common.Equidistant,
 		TraceDuration:       1,
 
 		Functions: []*common.Function{
@@ -580,9 +579,11 @@ func TestDriverCompletely(t *testing.T) {
 			driver.Configuration.TraceGranularity = test.traceGranularity
 
 			// Deprecating driver.GenerateSpecification()
+			iatDistribution := common.Equidistant
+			shiftIAT := false
 			generator.GenerateAzure2019Specification(
 				driver.Configuration.Functions, driver.Configuration.LoaderConfiguration,
-				driver.Configuration.IATDistribution, driver.Configuration.ShiftIAT, driver.Configuration.TraceGranularity)
+				iatDistribution, shiftIAT, driver.Configuration.TraceGranularity)
 
 			driver.RunExperiment()
 
@@ -680,9 +681,11 @@ func TestVSwarmDriverCompletely(t *testing.T) {
 			driver.Configuration.TraceGranularity = test.traceGranularity
 
 			// Deprecating driver.GenerateSpecification()
+			iatDistribution := common.Equidistant
+			shiftIAT := false
 			generator.GenerateAzure2019Specification(
 				driver.Configuration.Functions, driver.Configuration.LoaderConfiguration,
-				driver.Configuration.IATDistribution, driver.Configuration.ShiftIAT, driver.Configuration.TraceGranularity)
+				iatDistribution, shiftIAT, driver.Configuration.TraceGranularity)
 
 			driver.RunExperiment()
 

--- a/pkg/generator/rps.go
+++ b/pkg/generator/rps.go
@@ -2,11 +2,14 @@ package generator
 
 import (
 	"fmt"
+	"log"
+	"math"
+	"math/rand"
+	"strings"
+
 	"github.com/sirupsen/logrus"
 	"github.com/vhive-serverless/loader/pkg/common"
 	"github.com/vhive-serverless/loader/pkg/config"
-	"math"
-	"math/rand"
 )
 
 func generateFunctionByRPS(experimentDuration int, rpsTarget float64) common.IATArray {
@@ -105,33 +108,20 @@ func GenerateColdStartFunctions(experimentDuration int, rpsTarget float64, coold
 	return functions, countResult
 }
 
-func CreateRPSFunctions(cfg *config.LoaderConfiguration, dcfg *config.DirigentConfig, warmFunction common.IATArray, warmFunctionCount []int,
+// Generates []*common.Function based on intended warm/cold functionality, does not generate dirigent metadata.
+func CreateRPSFunctions(cfg *config.LoaderConfiguration, warmFunction common.IATArray, warmFunctionCount []int,
 	coldFunctions []common.IATArray, coldFunctionCount [][]int, yamlPath string) []*common.Function {
 	var result []*common.Function
 
 	busyLoopFor := ComputeBusyLoopPeriod(cfg.RpsMemoryMB)
 
 	if warmFunction != nil || warmFunctionCount != nil {
-		var dirigentMetadataWarm *common.DirigentMetadata
-		if dcfg != nil {
-			dirigentMetadataWarm = &common.DirigentMetadata{
-				Image:               dcfg.RpsImage,
-				Port:                80,
-				Protocol:            "tcp",
-				ScalingUpperBound:   1024,
-				ScalingLowerBound:   1,
-				IterationMultiplier: cfg.RpsIterationMultiplier,
-				IOPercentage:        0,
-			}
-		}
-
 		result = append(result, &common.Function{
 			Name: fmt.Sprintf("warm-function-%d", rand.Int()),
 
 			InvocationStats:  &common.FunctionInvocationStats{Invocations: warmFunctionCount},
 			RuntimeStats:     &common.FunctionRuntimeStats{Average: float64(cfg.RpsRuntimeMs)},
 			MemoryStats:      &common.FunctionMemoryStats{Percentile100: float64(cfg.RpsMemoryMB)},
-			DirigentMetadata: dirigentMetadataWarm,
 
 			Specification: &common.FunctionSpecification{
 				IAT:                  warmFunction,
@@ -145,25 +135,11 @@ func CreateRPSFunctions(cfg *config.LoaderConfiguration, dcfg *config.DirigentCo
 	}
 
 	for i := 0; i < len(coldFunctions); i++ {
-		var dirigentMetadataCold *common.DirigentMetadata
-		if dcfg != nil {
-			dirigentMetadataCold = &common.DirigentMetadata{
-				Image:               dcfg.RpsImage,
-				Port:                80,
-				Protocol:            "tcp",
-				ScalingUpperBound:   1,
-				ScalingLowerBound:   0,
-				IterationMultiplier: cfg.RpsIterationMultiplier,
-				IOPercentage:        0,
-			}
-		}
-
 		result = append(result, &common.Function{
 			Name: fmt.Sprintf("cold-function-%d-%d", i, rand.Int()),
 
 			InvocationStats:  &common.FunctionInvocationStats{Invocations: coldFunctionCount[i]},
 			MemoryStats:      &common.FunctionMemoryStats{Percentile100: float64(cfg.RpsMemoryMB)},
-			DirigentMetadata: dirigentMetadataCold,
 
 			Specification: &common.FunctionSpecification{
 				IAT:                  coldFunctions[i],
@@ -178,6 +154,52 @@ func CreateRPSFunctions(cfg *config.LoaderConfiguration, dcfg *config.DirigentCo
 
 	return result
 }
+
+// TODO consider pointer receiver for []*functions
+
+// Attaches 2 possible DirigentMetadata property, depending if function is cold or warm (based on function name) for RPS function.
+func AppendDirigentMetadata(cfg *config.LoaderConfiguration, dcfg *config.DirigentConfig, functions []*common.Function) []*common.Function {
+
+	var dirigentMetadataWarm *common.DirigentMetadata
+	if dcfg != nil {
+		dirigentMetadataWarm = &common.DirigentMetadata{
+			Image:               dcfg.RpsImage,
+			Port:                80,
+			Protocol:            "tcp",
+			ScalingUpperBound:   1024,
+			ScalingLowerBound:   1,
+			IterationMultiplier: cfg.RpsIterationMultiplier,
+			IOPercentage:        0,
+		}
+	}
+
+	var dirigentMetadataCold *common.DirigentMetadata
+	if dcfg != nil {
+		dirigentMetadataCold = &common.DirigentMetadata{
+			Image:               dcfg.RpsImage,
+			Port:                80,
+			Protocol:            "tcp",
+			ScalingUpperBound:   1,
+			ScalingLowerBound:   0,
+			IterationMultiplier: cfg.RpsIterationMultiplier,
+			IOPercentage:        0,
+		}
+	}
+
+	// Appends cold/warm metadata based on function's name.
+	for _, function := range functions {
+		if strings.Contains(function.Name, "warm-function"){
+			function.DirigentMetadata = dirigentMetadataWarm
+		} else if strings.Contains(function.Name, "cold-function") {
+			function.DirigentMetadata = dirigentMetadataCold
+		} else {
+			log.Fatal("When adding dirigent meta-data for RPS trace input, unable to determine DirigentMetaData to add.")
+		}
+	}
+
+	return functions
+}
+
 
 func createRuntimeSpecification(count int, runtime, memory int) common.RuntimeSpecificationArray {
 	var result common.RuntimeSpecificationArray

--- a/pkg/generator/rps.go
+++ b/pkg/generator/rps.go
@@ -158,7 +158,7 @@ func CreateRPSFunctions(cfg *config.LoaderConfiguration, warmFunction common.IAT
 // TODO consider pointer receiver for []*functions
 
 // Attaches 2 possible DirigentMetadata property, depending if function is cold or warm (based on function name) for RPS function.
-func AppendDirigentMetadata(cfg *config.LoaderConfiguration, dcfg *config.DirigentConfig, functions []*common.Function) []*common.Function {
+func AppendDirigentMetadata(functions []*common.Function, cfg *config.LoaderConfiguration, dcfg *config.DirigentConfig) {
 
 	var dirigentMetadataWarm *common.DirigentMetadata
 	if dcfg != nil {
@@ -196,8 +196,6 @@ func AppendDirigentMetadata(cfg *config.LoaderConfiguration, dcfg *config.Dirige
 			log.Fatal("When adding dirigent meta-data for RPS trace input, unable to determine DirigentMetaData to add.")
 		}
 	}
-
-	return functions
 }
 
 

--- a/pkg/generator/rps.go
+++ b/pkg/generator/rps.go
@@ -108,7 +108,7 @@ func GenerateColdStartFunctions(experimentDuration int, rpsTarget float64, coold
 	return functions, countResult
 }
 
-// Generates []*common.Function based on intended warm/cold functionality, does not generate dirigent metadata.
+// Generates []*common.Function based on intended warm/cold functionality
 func CreateRPSFunctions(cfg *config.LoaderConfiguration, warmFunction common.IATArray, warmFunctionCount []int,
 	coldFunctions []common.IATArray, coldFunctionCount [][]int, yamlPath string) []*common.Function {
 	var result []*common.Function
@@ -119,9 +119,9 @@ func CreateRPSFunctions(cfg *config.LoaderConfiguration, warmFunction common.IAT
 		result = append(result, &common.Function{
 			Name: fmt.Sprintf("warm-function-%d", rand.Int()),
 
-			InvocationStats:  &common.FunctionInvocationStats{Invocations: warmFunctionCount},
-			RuntimeStats:     &common.FunctionRuntimeStats{Average: float64(cfg.RpsRuntimeMs)},
-			MemoryStats:      &common.FunctionMemoryStats{Percentile100: float64(cfg.RpsMemoryMB)},
+			InvocationStats: &common.FunctionInvocationStats{Invocations: warmFunctionCount},
+			RuntimeStats:    &common.FunctionRuntimeStats{Average: float64(cfg.RpsRuntimeMs)},
+			MemoryStats:     &common.FunctionMemoryStats{Percentile100: float64(cfg.RpsMemoryMB)},
 
 			Specification: &common.FunctionSpecification{
 				IAT:                  warmFunction,
@@ -138,8 +138,8 @@ func CreateRPSFunctions(cfg *config.LoaderConfiguration, warmFunction common.IAT
 		result = append(result, &common.Function{
 			Name: fmt.Sprintf("cold-function-%d-%d", i, rand.Int()),
 
-			InvocationStats:  &common.FunctionInvocationStats{Invocations: coldFunctionCount[i]},
-			MemoryStats:      &common.FunctionMemoryStats{Percentile100: float64(cfg.RpsMemoryMB)},
+			InvocationStats: &common.FunctionInvocationStats{Invocations: coldFunctionCount[i]},
+			MemoryStats:     &common.FunctionMemoryStats{Percentile100: float64(cfg.RpsMemoryMB)},
 
 			Specification: &common.FunctionSpecification{
 				IAT:                  coldFunctions[i],
@@ -154,8 +154,6 @@ func CreateRPSFunctions(cfg *config.LoaderConfiguration, warmFunction common.IAT
 
 	return result
 }
-
-// TODO consider pointer receiver for []*functions
 
 // Attaches 2 possible DirigentMetadata property, depending if function is cold or warm (based on function name) for RPS function.
 func AppendDirigentMetadata(functions []*common.Function, cfg *config.LoaderConfiguration, dcfg *config.DirigentConfig) {
@@ -188,7 +186,7 @@ func AppendDirigentMetadata(functions []*common.Function, cfg *config.LoaderConf
 
 	// Appends cold/warm metadata based on function's name.
 	for _, function := range functions {
-		if strings.Contains(function.Name, "warm-function"){
+		if strings.Contains(function.Name, "warm-function") {
 			function.DirigentMetadata = dirigentMetadataWarm
 		} else if strings.Contains(function.Name, "cold-function") {
 			function.DirigentMetadata = dirigentMetadataCold
@@ -197,7 +195,6 @@ func AppendDirigentMetadata(functions []*common.Function, cfg *config.LoaderConf
 		}
 	}
 }
-
 
 func createRuntimeSpecification(count int, runtime, memory int) common.RuntimeSpecificationArray {
 	var result common.RuntimeSpecificationArray

--- a/pkg/generator/specification.go
+++ b/pkg/generator/specification.go
@@ -29,6 +29,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/vhive-serverless/loader/pkg/common"
+
+	"github.com/vhive-serverless/loader/pkg/config"
 )
 
 type SpecificationGenerator struct {
@@ -181,6 +183,33 @@ func (s *SpecificationGenerator) GenerateInvocationData(function *common.Functio
 		PerMinuteCount:       perMinuteCount,
 		RawDuration:          rawDuration,
 		RuntimeSpecification: runtimeArray,
+	}
+}
+
+//////////////////////////////////////////////////
+// TOP LEVEL INTERFACE
+//////////////////////////////////////////////////
+
+// Generates IATs and runtime specifications for Azure2019 trace type,
+// Updates `functions` with Specification filled.
+func GenerateAzure2019Specification(functions []*common.Function, loaderCfg *config.LoaderConfiguration, IATDistribution common.IatDistribution, shiftIAT bool, traceGranularity common.TraceGranularity) {
+	log.Info("Generating IAT and runtime specifications for all the functions")
+
+	azure2019Generator := NewSpecificationGenerator(loaderCfg.Seed)
+
+	for i, function := range functions {
+		// Equalising all the InvocationStats to the first function
+		if loaderCfg.DAGMode {
+			function.InvocationStats.Invocations = functions[0].InvocationStats.Invocations
+		}
+		spec := azure2019Generator.GenerateInvocationData(
+			function,
+			IATDistribution,
+			shiftIAT,
+			traceGranularity,
+		)
+
+		functions[i].Specification = spec
 	}
 }
 

--- a/pkg/generator/specification.go
+++ b/pkg/generator/specification.go
@@ -141,7 +141,7 @@ func getBlankTimeUnit(granularity common.TraceGranularity) float64 {
 	}
 }
 
-// GenerateIAT generates IAT according to the given distribution. Number of minutes is the length of invocationsPerMinute array
+// GenerateIAT generates IAT according to the given distribution.
 func (s *SpecificationGenerator) generateIAT(invocationsPerMinute []int, iatDistribution common.IatDistribution,
 	shiftIAT bool, granularity common.TraceGranularity) (common.IATArray, []int, common.ProbabilisticDuration) {
 

--- a/pkg/trace/azure_trace_parser_test.go
+++ b/pkg/trace/azure_trace_parser_test.go
@@ -25,10 +25,11 @@
 package trace
 
 import (
-	"github.com/vhive-serverless/loader/pkg/common"
 	"math"
 	"strings"
 	"testing"
+
+	"github.com/vhive-serverless/loader/pkg/common"
 )
 
 func floatEqual(n, expected float64) bool {

--- a/pkg/trace/dirigent_metadata_parser.go
+++ b/pkg/trace/dirigent_metadata_parser.go
@@ -2,10 +2,11 @@ package trace
 
 import (
 	"encoding/json"
-	log "github.com/sirupsen/logrus"
-	"github.com/vhive-serverless/loader/pkg/common"
 	"os"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/vhive-serverless/loader/pkg/common"
 )
 
 type DirigentMetadataParser struct {
@@ -46,6 +47,8 @@ func readDirigentMetadataJSON(traceFile string, platform string) *[]common.Dirig
 	return &metadata
 }
 
+// Reads Dirigent trace meta-data, and places into *common.Function as property "dirigentMetadata"
+// Or if Knative yaml is provided, converts it to dirigent configurations. 
 func (dmp *DirigentMetadataParser) Parse() {
 	dirigentPath := dmp.directoryPath + "/dirigent.json"
 	dirigentMetadata := readDirigentMetadataJSON(dirigentPath, dmp.platform)


### PR DESCRIPTION
## Summary
Refactored Loader.
Ensure more clear separation of function parsing/generation, dirigent reading, driver running. 

## Implementation Notes :hammer_and_pick:
Added traceInputType variable classification
Combined runRPS() and runTrace() into singular runMode()

Driver should use []*common.function directly, extracted function generation out of driver.
Driver should not handle function read/write to file, extract out of driver.

Dirigent metadata adding extracted out of function generation, takes a dedicated section of runMode()
RPS function generation rewritten to extract dirigent metadata adding out.

## External Dependencies :four_leaf_clover:
N/A

## Breaking API Changes :warning:
trace_driver_test had to be updated to use new function specification generation method.
driver.GenerateSpecification() => GenerateAzure2019Specification()