### PR TITLE
Allow Sampler to work with Azure2021 Function Traces

### DIFF
--- a/docs/sampler.md
+++ b/docs/sampler.md
@@ -187,7 +187,7 @@ The differences stems from the differences in trace:
 
 The preprocessing follows 3 steps:
 1. Filter for invocations within time interval (according to the user-defined start and end time)
-2. Remove functions with invocation rate of 0ms duration above threshold rate. (user-defined threshold)
+2. Remove functions with invocation rate of 0ms duration above threshold rate. Default threshold of 50%. (user-defined threshold)
 3. Transform the trace to azure2019 format. 
 
 While `inv_df` and `dur_df` can be calculated, `mem_df` is set to a static value of 200.

--- a/docs/sampler.md
+++ b/docs/sampler.md
@@ -173,7 +173,7 @@ in [`plotTimeline/analysis.ipynb`](/tools/plotTimeline/analysis.ipynb)
 ### Overview
 
 The sampling process of Azure2021 trace follows 3 steps: 
-1. Pre-process the original trace (`preprocess2021`) -> obtain clean trace.
+1. Pre-process the original trace (`preprocess2021`) -> obtain clean trace in azure2019 format.
 2. Run the sampler on cleaned trace (`sampler`) -> obtain down-sampled trace, which contains a list of functions to keep in azure2019 format.
 3. Filter the original trace for functions in list (`filter`) -> obtain down-sampled trace in azure2021 format (per-invocation format).
 
@@ -207,9 +207,9 @@ and extract the CSV files (default location: `data/azure2021/`).
 The following is an example usage of the sampler:
 
 ```console
-python -m sampler preprocess2021  -t data/azure2021/ -o data/traces/reference/preprocessed_azure2021 -s 00:01:00 -dur 100 -thresh 50
+python -m sampler preprocess2021 -t data/azure2021/original_trace_filename.txt -o data/traces/reference/preprocessed_azure2021 -s 00:01:00 -dur 100 -thresh 50
 
 python -m sampler sample -t data/traces/reference/preprocessed_azure2021 -orig data/traces/reference/preprocessed_azure2021 -o data/traces/reference/sampled_azure2021 -min 20 -st 5 -max 45 -tr 16
 
-python -m sampler filter2021  -t data/azure2021/ -st data/traces/reference/sampled_azure2021/samples/40 -o data/traces/reference/filtered2021 -s 00:01:00 -dur 100
+python -m sampler filter2021 -t data/azure2021/original_trace_filename.txt -st data/traces/reference/sampled_azure2021/samples/40 -o data/traces/reference/filtered2021 -s 00:01:00 -dur 100
 ```

--- a/docs/sampler.md
+++ b/docs/sampler.md
@@ -174,14 +174,14 @@ in [`plotTimeline/analysis.ipynb`](/tools/plotTimeline/analysis.ipynb)
 
 The sampling process of Azure2021 trace follows 3 steps: 
 1. Pre-process the original trace (`preprocess2021`) -> obtain clean trace.
-2. Run the sampler on cleaned trace (`sampler`) -> obtain downsampled trace, which contains a list of functions to keep in azure2019 format.
-3. Filter the original trace for functions in list (`filter`) -> obtain downsampled trace in azure2021 format (per-invocation format).
+2. Run the sampler on cleaned trace (`sampler`) -> obtain down-sampled trace, which contains a list of functions to keep in azure2019 format.
+3. Filter the original trace for functions in list (`filter`) -> obtain down-sampled trace in azure2021 format (per-invocation format).
 
 Functionality of modules emulates the normal azure2019 modules, the differences is discussed below.
 
 The differences stems from the differences in trace:
-- azure2021 traces are inovcation per row, while azure2019 is a function per row.
-- azure2021 traces does not have memory data.
+- azure2021 trace is invocation per row, while azure2019 is a function per row.
+- azure2021 trace does not have memory data.
 
 ### Preprocess2021
 
@@ -207,9 +207,9 @@ and extract the CSV files (default location: `data/azure2021/`).
 The following is an example usage of the sampler:
 
 ```console
-python -m sampler preprocess2021  -t data/azure2021/ -o data/traces/reference/preprocessedAzure2021 -s 00:01:00 -dur 100 -thresh 50
+python -m sampler preprocess2021  -t data/azure2021/ -o data/traces/reference/preprocessed_azure2021 -s 00:01:00 -dur 100 -thresh 50
 
-python -m sampler sample -t data/traces/reference/preprocessedAzure2021 -orig data/traces/reference/preprocessedAzure2021 -o data/traces/reference/sampledAzure2021 -min 20 -st 5 -max 50 -tr 16
+python -m sampler sample -t data/traces/reference/preprocessed_azure2021 -orig data/traces/reference/preprocessed_azure2021 -o data/traces/reference/sampled_azure2021 -min 20 -st 5 -max 45 -tr 16
 
-python -m sampler filter2021  -t data/azure2021/ -st data/traces/reference/sampledAzure2021/samples/40 -o data/traces/reference/filtered2021 -s 00:01:00 -dur 100
+python -m sampler filter2021  -t data/azure2021/ -st data/traces/reference/sampled_azure2021/samples/40 -o data/traces/reference/filtered2021 -s 00:01:00 -dur 100
 ```

--- a/docs/sampler.md
+++ b/docs/sampler.md
@@ -168,3 +168,48 @@ Tools that can be used to generate the timeline of a trace are available in the 
 
 A jupyter notebook containing examples of the timeline analysis is available
 in [`plotTimeline/analysis.ipynb`](/tools/plotTimeline/analysis.ipynb)
+
+## Using Azure2021 Traces
+### Overview
+
+The sampling process of Azure2021 trace follows 3 steps: 
+1. Pre-process the original trace (`preprocess2021`) -> obtain clean trace.
+2. Run the sampler on cleaned trace (`sampler`) -> obtain downsampled trace, which contains a list of functions to keep in azure2019 format.
+3. Filter the original trace for functions in list (`filter`) -> obtain downsampled trace in azure2021 format (per-invocation format).
+
+Functionality of modules emulates the normal azure2019 modules, the differences is discussed below.
+
+The differences stems from the differences in trace:
+- azure2021 traces are inovcation per row, while azure2019 is a function per row.
+- azure2021 traces does not have memory data.
+
+### Preprocess2021
+
+The preprocessing follows 3 steps:
+1. Filter for invocations within time interval (according to the user-defined start and end time)
+2. Remove functions with invocation rate of 0ms duration above threshold rate. (user-defined threshold)
+3. Transform the trace to azure2019 format. 
+
+While `inv_df` and `dur_df` can be calculated, `mem_df` is set to a static value of 200.
+
+### Filter
+
+Filter first filters for invocations in original trace within the time interval. 
+It then tracks all `HashApp` and `HashFunction` in sampled trace. 
+Using that, it filters the original trace and keeps all invocations with matching `app` and `func` values.
+
+### Workflow
+
+First, download the original Azure2021 trace files
+from [here](https://github.com/Azure/AzurePublicDataset/blob/master/AzureFunctionsInvocationTrace2021.md#downloading)
+and extract the CSV files (default location: `data/azure2021/`).
+
+The following is an example usage of the sampler:
+
+```console
+python -m sampler preprocess2021  -t data/azure2021/ -o data/traces/reference/preprocessedAzure2021 -s 00:01:00 -dur 100 -thresh 50
+
+python -m sampler sample -t data/traces/reference/preprocessedAzure2021 -orig data/traces/reference/preprocessedAzure2021 -o data/traces/reference/sampledAzure2021 -min 20 -st 5 -max 50 -tr 16
+
+python -m sampler filter2021  -t data/azure2021/ -st data/traces/reference/sampledAzure2021/samples/40 -o data/traces/reference/filtered2021 -s 00:01:00 -dur 100
+```

--- a/sampler/__main__.py
+++ b/sampler/__main__.py
@@ -67,13 +67,13 @@ def run(args):
         return
     
     if args.cmd == 'preprocess2021':
-        preprocess_file(trace_dir=args.trace, start_time=args.start, duration=args.duration, 
+        preprocess_file(trace_path=args.trace, start_time=args.start, duration=args.duration, 
                         output_dir=args.output, zero_ms_threshold_percent=args.threshold)
         return
     
     if args.cmd == 'filter2021':
-        filter_azure2021(orig_trace_dir=args.trace, sampled_trace_dir=args.sampled_trace, out_dir=args.output, 
-                         start_time=args.start, duration=args.duration, orig_trace_filename=args.trace_file)
+        filter_azure2021(orig_trace_path=args.trace, sampled_trace_dir=args.sampled_trace, out_dir=args.output, 
+                         start_time=args.start, duration=args.duration)
         return
 
     inv_df = pd.read_csv(f"{args.source_trace}/invocations.csv")
@@ -253,8 +253,8 @@ def main():
         '-t',
         '--trace',
         metavar='path',
-        default='data/2021',
-        help='Path to the Azure2021 trace directory'
+        default='data/2021/AzureFunctionsInvocationTraceForTwoWeeksJan2021.txt',
+        help='Path to the Azure2021 trace file'
     )
 
     pre2021_parser.add_argument(
@@ -262,7 +262,7 @@ def main():
         '--output',
         required=True,
         metavar='path',
-        help='Output path for the preprocessed traces'
+        help='Output directory for the preprocessed traces'
     )
 
     pre2021_parser.add_argument(
@@ -299,7 +299,7 @@ def main():
         '--trace',
         required=True,
         metavar='og_path',
-        help='Directory path to the original Azure2021 trace'
+        help='File path to the original Azure2021 trace'
     )
 
     filter2021_parser.add_argument(
@@ -332,14 +332,6 @@ def main():
         required=True,
         metavar='duration',
         help='Duration in minutes of the excerpt extracted from the postprocessed trace'
-    )
-
-    filter2021_parser.add_argument(
-        '-tf',
-        '--trace_file',
-        required=False,
-        metavar='trace_filename',
-        help='Filename of the original trace, if using non-default original trace other than `AzureFunctionsInvocationTraceForTwoWeeksJan2021.txt`'
     )
 
     ####################################################

--- a/sampler/__main__.py
+++ b/sampler/__main__.py
@@ -30,6 +30,7 @@ import pandas as pd
 # from sampler.plot import plot_cdf
 from sampler.preprocess import parse_trace_files
 from sampler.sample import generate_samples
+from sampler.preprocess2021 import preprocess_file
 
 log.basicConfig(format='%(levelname)s:%(message)s', level=log.INFO)
 
@@ -62,6 +63,11 @@ def run(args):
         mem_df.to_csv(f"{args.output}/memory.csv", index=False)
         run_df.to_csv(f"{args.output}/durations.csv", index=False)
 
+        return
+    
+    if args.cmd == 'preprocess2021':
+        preprocess_file(trace_dir=args.trace, start_time=args.start, duration=args.duration, 
+                        output_dir=args.output, zero_ms_threshold_percent=args.threshold)
         return
 
     inv_df = pd.read_csv(f"{args.source_trace}/invocations.csv")
@@ -235,7 +241,48 @@ def main():
 
     ####################################################
 
-    
+    pre2021_parser = subparser.add_parser('preprocess2021')
+
+    pre2021_parser.add_argument(
+        '-t',
+        '--trace',
+        metavar='path',
+        default='data/2021',
+        help='Path to the Azure2021 trace directory'
+    )
+
+    pre2021_parser.add_argument(
+        '-o',
+        '--output',
+        required=True,
+        metavar='path',
+        help='Output path for the preprocessed traces'
+    )
+
+    pre2021_parser.add_argument(
+        '-s',
+        '--start',
+        required=True,
+        metavar='start',
+        help='Time in dd:hh:mm format, at which the excerpt of the postprocessed trace should begin, first day is day 0'
+    )
+
+    pre2021_parser.add_argument(
+        '-dur',
+        '--duration',
+        required=True,
+        metavar='duration',
+        help='Duration in minutes of the excerpt extracted from the postprocessed trace'
+    )
+
+    pre2021_parser.add_argument(
+        '-thresh',
+        '--threshold',
+        required=False,
+        default=50,
+        metavar='threshold',
+        help='Threshold in percentage, for which a function is ignored if the percentage of its 0ms invocations is equal or higher'
+    )
 
     ####################################################
 

--- a/sampler/__main__.py
+++ b/sampler/__main__.py
@@ -31,6 +31,7 @@ import pandas as pd
 from sampler.preprocess import parse_trace_files
 from sampler.sample import generate_samples
 from sampler.preprocess2021 import preprocess_file
+from sampler.filter import filter_azure2021
 
 log.basicConfig(format='%(levelname)s:%(message)s', level=log.INFO)
 
@@ -68,6 +69,10 @@ def run(args):
     if args.cmd == 'preprocess2021':
         preprocess_file(trace_dir=args.trace, start_time=args.start, duration=args.duration, 
                         output_dir=args.output, zero_ms_threshold_percent=args.threshold)
+        return
+    
+    if args.cmd == 'filter2021':
+        filter_azure2021(orig_trace_dir=args.trace, sampled_trace_dir=args.sampled_trace, out_dir=args.output, start_time=args.start, duration=args.duration)
         return
 
     inv_df = pd.read_csv(f"{args.source_trace}/invocations.csv")
@@ -285,6 +290,51 @@ def main():
     )
 
     ####################################################
+
+    filter2021_parser = subparser.add_parser('filter2021')
+
+    filter2021_parser.add_argument(
+        '-t',
+        '--trace',
+        required=True,
+        metavar='og_path',
+        help='Directory path to the original Azure2021 trace'
+    )
+
+    filter2021_parser.add_argument(
+        '-st',
+        '--sampled_trace',
+        required=True,
+        metavar='samp_path',
+        help='Directory path to trace output of sample command'
+    )
+
+    filter2021_parser.add_argument(
+        '-o',
+        '--output',
+        required=True,
+        metavar='out_path',
+        help='Directory path for output of final filtered azure2021 trace'
+    )
+
+    filter2021_parser.add_argument(
+        '-s',
+        '--start',
+        required=True,
+        metavar='start',
+        help='Time in dd:hh:mm format, at which the excerpt of the postprocessed trace should begin, first day is day 0'
+    )
+
+    filter2021_parser.add_argument(
+        '-dur',
+        '--duration',
+        required=True,
+        metavar='duration',
+        help='Duration in minutes of the excerpt extracted from the postprocessed trace'
+    )
+
+    ####################################################
+
 
     args = parser.parse_args()
 

--- a/sampler/__main__.py
+++ b/sampler/__main__.py
@@ -95,6 +95,7 @@ def main():
     parser = argparse.ArgumentParser()
     subparser = parser.add_subparsers(dest="cmd")
 
+    ####################################################
     sample_parser = subparser.add_parser('sample')
 
     sample_parser.add_argument(
@@ -231,6 +232,10 @@ def main():
         metavar='duration',
         help='Duration in minutes of the excerpt extracted from the postprocessed trace'
     )
+
+    ####################################################
+
+    
 
     ####################################################
 

--- a/sampler/__main__.py
+++ b/sampler/__main__.py
@@ -72,7 +72,8 @@ def run(args):
         return
     
     if args.cmd == 'filter2021':
-        filter_azure2021(orig_trace_dir=args.trace, sampled_trace_dir=args.sampled_trace, out_dir=args.output, start_time=args.start, duration=args.duration)
+        filter_azure2021(orig_trace_dir=args.trace, sampled_trace_dir=args.sampled_trace, out_dir=args.output, 
+                         start_time=args.start, duration=args.duration, orig_trace_filename=args.trace_file)
         return
 
     inv_df = pd.read_csv(f"{args.source_trace}/invocations.csv")
@@ -331,6 +332,14 @@ def main():
         required=True,
         metavar='duration',
         help='Duration in minutes of the excerpt extracted from the postprocessed trace'
+    )
+
+    filter2021_parser.add_argument(
+        '-tf',
+        '--trace_file',
+        required=False,
+        metavar='trace_filename',
+        help='Filename of the original trace, if using non-default original trace other than `AzureFunctionsInvocationTraceForTwoWeeksJan2021.txt`'
     )
 
     ####################################################

--- a/sampler/filter.py
+++ b/sampler/filter.py
@@ -28,12 +28,10 @@ from glob import glob
 
 from sampler.preprocess2021 import filter_within_time_interval
 
-def filter_azure2021(orig_trace_dir: str, sampled_trace_dir: str, out_dir: str, start_time: str, duration: int, orig_trace_filename: str = None):
-    if orig_trace_filename is None:
-        orig_trace_filename = "AzureFunctionsInvocationTraceForTwoWeeksJan2021.txt"
-
+def filter_azure2021(orig_trace_path: str, sampled_trace_dir: str, out_dir: str, start_time: str, duration: int):
+    
     # Read original trace
-    trace_file = glob(f"{orig_trace_dir}/{orig_trace_filename}")
+    trace_file = glob(f"{orig_trace_path}")
     assert len(trace_file) == 1, "Expected 1 Azure2021 trace file"
     trace_df = pd.read_csv(trace_file[0])
 
@@ -63,15 +61,3 @@ def filter_azure2021(orig_trace_dir: str, sampled_trace_dir: str, out_dir: str, 
         
     log.info(f"Saving sampled Azure2021 to {out_dir}/SampledAzure2021.csv")
     trace_df.to_csv(f"{out_dir}/SampledAzure2021.csv", index=False)
-
-if __name__ == "__main__":
-    orig_trace_dir = "data/azure2021/"
-    sampled_trace_dir = "data/traces/reference/sampledAzure2021/" + "samples/40"
-    out_dir = "data/traces/reference/filtered2021"
-    start_time = "00:01:00"
-    duration = 100
-
-    log.basicConfig(format='%(levelname)s:%(message)s', level=log.INFO)
-
-    filter_azure2021(orig_trace_dir, sampled_trace_dir, out_dir, start_time, duration)
-

--- a/sampler/filter.py
+++ b/sampler/filter.py
@@ -1,0 +1,76 @@
+#  MIT License
+#
+#  Copyright (c) 2023 EASL and the vHive community
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in all
+#  copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#  SOFTWARE.
+
+import logging as log
+import pandas as pd
+
+import os
+from glob import glob
+
+from sampler.preprocess2021 import filter_within_time_interval
+
+def filter_azure2021(orig_trace_dir: str, sampled_trace_dir: str, out_dir: str, start_time: str, duration: int):
+
+    # Read original trace
+    trace_file = glob(f"{orig_trace_dir}/AzureFunctionsInvocationTraceForTwoWeeksJan2021.txt")
+    assert len(trace_file) == 1, "Expected 1 Azure2021 trace file"
+    trace_df = pd.read_csv(trace_file[0])
+
+    # Read sampled trace
+    invocations_file = glob(f"{sampled_trace_dir}/invocations.csv")
+    assert len(invocations_file) == 1, "Expected 1 invocations file"
+    inv_df = pd.read_csv(invocations_file[0])
+
+    # Filter original trace to keep sampled functions
+    trace_df, _, _ = filter_within_time_interval(trace_df, start_time, duration)
+
+    inv_df = inv_df.rename(columns={'HashApp': 'app', 'HashFunction': 'func'})
+    functions_to_keep_keys = inv_df[['app', 'func']].drop_duplicates()
+    trace_df = trace_df.merge(functions_to_keep_keys, on=['app', 'func'], how='inner')
+
+    # Cleanup
+    trace_df = trace_df.drop(columns=['start_timestamp'])
+
+    # Save to file
+    log.info(f"The final sampled trace contains: {len(trace_df)} rows and {len(trace_df.groupby(['app', 'func']))} functions")
+
+    # Save to directory
+    if not os.path.exists(out_dir):
+        try:
+            os.makedirs(out_dir)
+        except OSError as e:
+            raise RuntimeError(f"Failed to create the output folder: {e}")
+        
+    log.info(f"Saving sampled Azure2021 to {out_dir}/SampledAzure2021.csv")
+    trace_df.to_csv(f"{out_dir}/SampledAzure2021.csv", index=False) # consider writing number of samples
+
+if __name__ == "__main__":
+    orig_trace_dir = "data/azure2021/"
+    sampled_trace_dir = "data/traces/reference/sampledAzure2021/" + "samples/40"
+    out_dir = "data/traces/reference/filtered2021"
+    start_time = "00:01:00"
+    duration = 100
+
+    log.basicConfig(format='%(levelname)s:%(message)s', level=log.INFO)
+
+    filter_azure2021(orig_trace_dir, sampled_trace_dir, out_dir, start_time, duration)
+

--- a/sampler/filter.py
+++ b/sampler/filter.py
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2023 EASL and the vHive community
+#  Copyright (c) 2026 HySCALE and vHive community
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -28,10 +28,12 @@ from glob import glob
 
 from sampler.preprocess2021 import filter_within_time_interval
 
-def filter_azure2021(orig_trace_dir: str, sampled_trace_dir: str, out_dir: str, start_time: str, duration: int):
+def filter_azure2021(orig_trace_dir: str, sampled_trace_dir: str, out_dir: str, start_time: str, duration: int, orig_trace_filename: str = None):
+    if orig_trace_filename is None:
+        orig_trace_filename = "AzureFunctionsInvocationTraceForTwoWeeksJan2021.txt"
 
     # Read original trace
-    trace_file = glob(f"{orig_trace_dir}/AzureFunctionsInvocationTraceForTwoWeeksJan2021.txt")
+    trace_file = glob(f"{orig_trace_dir}/{orig_trace_filename}")
     assert len(trace_file) == 1, "Expected 1 Azure2021 trace file"
     trace_df = pd.read_csv(trace_file[0])
 
@@ -50,10 +52,9 @@ def filter_azure2021(orig_trace_dir: str, sampled_trace_dir: str, out_dir: str, 
     # Cleanup
     trace_df = trace_df.drop(columns=['start_timestamp'])
 
-    # Save to file
     log.info(f"The final sampled trace contains: {len(trace_df)} rows and {len(trace_df.groupby(['app', 'func']))} functions")
 
-    # Save to directory
+    # Save to file at directory
     if not os.path.exists(out_dir):
         try:
             os.makedirs(out_dir)

--- a/sampler/filter.py
+++ b/sampler/filter.py
@@ -61,7 +61,7 @@ def filter_azure2021(orig_trace_dir: str, sampled_trace_dir: str, out_dir: str, 
             raise RuntimeError(f"Failed to create the output folder: {e}")
         
     log.info(f"Saving sampled Azure2021 to {out_dir}/SampledAzure2021.csv")
-    trace_df.to_csv(f"{out_dir}/SampledAzure2021.csv", index=False) # consider writing number of samples
+    trace_df.to_csv(f"{out_dir}/SampledAzure2021.csv", index=False)
 
 if __name__ == "__main__":
     orig_trace_dir = "data/azure2021/"

--- a/sampler/preprocess2021.py
+++ b/sampler/preprocess2021.py
@@ -20,7 +20,8 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #  SOFTWARE.
 
-from numpy import s_ 
+from cycler import L
+from numpy import dsplit, s_ 
 import pandas as pd
 import logging as log
 import numpy as np
@@ -32,37 +33,43 @@ import math
 
 import os
 
-def preprocess_file(trace_dir: str, start_time: str, duration: str, output_dir: str) -> pd.DataFrame:
+def preprocess_file(trace_dir: str, start_time: str, duration: str, output_dir: str, zero_ms_threshold_percent:str) -> pd.DataFrame:
     
     # Read CSV
     trace_file = glob(f"{trace_dir}/AzureFunctionsInvocationTraceForTwoWeeksJan2021.txt")
     assert len(trace_file) == 1, "There exists only 1 Azure2021 trace file"
     df = pd.read_csv(trace_file[0])
 
-    # Keep invocations within interval
-    df, start_td, end_td = time_slice(df, start_time, duration)
+    # Time interval filter
+    df, start_td, end_td = filter_within_time_interval(df, start_time, duration)
 
-    # TODO: Determine if zero duration keep or throw? (see if loader parses correctly.)
+    # Filter functions with invocations below 1ms
+    df = filter_functions_with_0ms_inovcations(df, threshold_percent=int(zero_ms_threshold_percent))
 
-    # Validate no NaN
+    # Validation
     df = df.dropna()
     assert df.isna().sum().sum() == 0
 
-    # Transform into sampler's expected format.
+    # Transform format
     inv_df, mem_df, dur_df = transform_to_sampler_format(df, start_td, end_td)
 
+    log.info(f"The final dfs contain rows: "
+             f"inv={len(inv_df)}, mem={len(mem_df)}, dur={len(dur_df)}")
+    
     # Save to directory
     if not os.path.exists(output_dir):
         try:
             os.makedirs(output_dir)
         except OSError as e:
             raise RuntimeError(f"Failed to create the output folder: {e}")
-
+        
+    log.info(f"Saving dfs to {output_dir}")
     inv_df.to_csv(f"{output_dir}/invocations.csv", index=False)
     mem_df.to_csv(f"{output_dir}/memory.csv", index=False)
     dur_df.to_csv(f"{output_dir}/durations.csv", index=False)
 
-def time_slice(df: pd.DataFrame, start_time: str, duration: str) -> Tuple[pd.DataFrame, pd.Timedelta, pd.Timedelta]:
+# Filter for invocation from [start_time, start_time+duration_mintues]
+def filter_within_time_interval(df: pd.DataFrame, start_time: str, duration_minutes: str) -> Tuple[pd.DataFrame, pd.Timedelta, pd.Timedelta]:
     
     # Generate start time
     df['start_timestamp'] = df['end_timestamp'] - df['duration']
@@ -73,7 +80,7 @@ def time_slice(df: pd.DataFrame, start_time: str, duration: str) -> Tuple[pd.Dat
     day = int(start_time[0])
     hours = int(start_time[1])
     minutes = int(start_time[2])
-    duration = int(duration)
+    duration = int(duration_minutes)
 
     interval_start = pd.Timedelta(days=day, hours=hours, minutes=minutes)
     interval_end = pd.Timedelta(days=day, hours=hours, minutes=(minutes+duration))
@@ -81,14 +88,63 @@ def time_slice(df: pd.DataFrame, start_time: str, duration: str) -> Tuple[pd.Dat
     # Get time interval slice
     df = df[df['start_timestamp'].between(interval_start, interval_end)]
 
+    if (interval_end > pd.Timedelta(days=14, hours=0, minutes=0)):
+        log.warning(f"interval_end includes time after 14 days. azure2021 only has 14 days of invocations, ensure start_time and duration entered is intended.")
+
+    log.info(f"The time interval contains: {len(df)} invocations and {len(df.groupby(['app', 'func']))} functions")
+
     return df, interval_start, interval_end
+
+# Remove functions with invocation of 0ms above threshold rate.
+# This is to keep in line with preprocess.py's remove_zero_duration() which "Removes functions with an average execution time of 0 ms"
+def filter_functions_with_0ms_inovcations(df: pd.DataFrame, threshold_percent: int):
+
+    duration_grouped_df = df.groupby(['app', 'func'])['duration'].agg(list).reset_index()
+
+    # Indicate which functions have 0ms invocations above threshold percent.
+    duration_grouped_df = duration_grouped_df.apply(indicate_functions_with_0ms, threshold_percent=threshold_percent, axis=1)
+
+    # Display to user count/percentage of functions/invocations removed
+    total_functions_count = len(duration_grouped_df)
+    total_invocation_count = duration_grouped_df['total_invocation_count'].sum()
+
+    functions_to_remove = duration_grouped_df[duration_grouped_df['filter_out'] == 1]
+    functions_removed_count = len(functions_to_remove)
+    invocation_removed_count = functions_to_remove['total_invocation_count'].sum()
+
+    log.info(f"Removing functions with 0ms invocations rate above {threshold_percent}%:")
+    log.info(f"Removing {functions_removed_count} of {total_functions_count} functions ({(functions_removed_count/total_functions_count):.2%})")
+    log.info(f"Removing {invocation_removed_count} of {total_invocation_count} invocations ({(invocation_removed_count/total_invocation_count):.2%})")
+
+    # Keep in original df, the rows with ['app','func'] that are below threshold.
+    functions_to_keep = duration_grouped_df[duration_grouped_df['filter_out'] == 0]
+    valid_keys = functions_to_keep[['app', 'func']].drop_duplicates()
+    # Inner join
+    df = df.merge(valid_keys, on=['app', 'func'], how='inner')
+
+    return df
+    
+def indicate_functions_with_0ms(row, threshold_percent):
+    duration_list = row['duration']
+    zero_invocation_count = duration_list.count(0)
+    total_invocation_count = len(duration_list)
+
+    if (zero_invocation_count/total_invocation_count >= threshold_percent/100):
+        row['filter_out'] = 1
+        row['total_invocation_count'] = total_invocation_count
+        log.debug(f"Row with 0ms_invocation above threshold \n{row}")
+    else: 
+        row['filter_out'] = 0
+        row['total_invocation_count'] = total_invocation_count
+
+    return row
 
 def transform_to_sampler_format(df: pd.DataFrame, interval_start: pd.Timedelta, interval_end: pd.Timedelta
                                 ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     
     # Determine invocation minute bins
     start_minute = math.floor((interval_start.total_seconds() / 60))
-    start_minute_bin = start_minute + 1 # Azure2019 starts from minute 1. (invocations in the first minute)
+    start_minute_bin = start_minute + 1 # Azure2019 tracks invocations within Xth minute.
     
     end_minute = math.floor((interval_end.total_seconds() / 60))
     end_minute_bin = end_minute + 1
@@ -102,15 +158,14 @@ def transform_to_sampler_format(df: pd.DataFrame, interval_start: pd.Timedelta, 
     dur_df = generate_dur_df(df)
 
     return inv_df, mem_df, dur_df
-    
+
+# Determine invocation count in a per-minute bin basis
 def generate_inv_df(df: pd.DataFrame, start_minute_bin: int, end_minute_bin: int) -> pd.DataFrame:
     
-    # INV_DF Determine invocation data in a per-minute bin-basis
-    # Set new columns, add per-minute bins
+    # Add per-minute bins columns
     new_columns = ["HashOwner", "HashApp", "HashFunction", "Trigger"] + list(range(start_minute_bin, end_minute_bin)) + ["start_timestamp"]
     df = df.reindex(columns=new_columns, fill_value=0) 
 
-    # Apply the function across rows (axis=1)  
     df = df.apply(bin_timestamps, axis=1)
 
     # Cleanup
@@ -120,18 +175,21 @@ def generate_inv_df(df: pd.DataFrame, start_minute_bin: int, end_minute_bin: int
 
     return df
 
+# Bin timestamps to minute bins
 def bin_timestamps(row):
-    # Parse timestamps, determine bin
     timestamp_list = row['start_timestamp']
     for timestamp in timestamp_list:
         timestamp_minute_bin = math.floor((timestamp.total_seconds() / 60)) + 1
 
-        # Increment count 
         row[timestamp_minute_bin] += 1 
     return row
 
-#TODO: Test
+# Memory usage percentiles set as static 200 value
 def generate_mem_df(df: pd.DataFrame) -> pd.DataFrame:
+    static_value = 200.0
+
+    log.info(f"Generating mem_df using static memory value of {static_value}")
+
     new_columns = [
         "HashFunction", "HashOwner", "HashApp", "SampleCount", 
         "AverageAllocatedMb", "AverageAllocatedMb_pct1", "AverageAllocatedMb_pct5", "AverageAllocatedMb_pct25"
@@ -140,7 +198,7 @@ def generate_mem_df(df: pd.DataFrame) -> pd.DataFrame:
     df = df.reindex(columns=new_columns) 
 
     df['SampleCount'] = df['start_timestamp'].str.len() #TODO: Determine if SampleCount needs a particular value, what reference value to use.
-    df = df.fillna(200.0) # 200MB, based on average stated in Azure2019
+    df = df.fillna(static_value) # 200MB, based on average stated in Azure2019
 
     # Cleanup
     df = df.drop(columns=["start_timestamp"])
@@ -148,7 +206,7 @@ def generate_mem_df(df: pd.DataFrame) -> pd.DataFrame:
 
     return df
 
-#TODO: Test
+# Calculate statistics from duration list
 def generate_dur_df(df: pd.DataFrame) -> pd.DataFrame:
     new_columns = [
         "HashOwner", "HashApp", "HashFunction", 
@@ -158,7 +216,6 @@ def generate_dur_df(df: pd.DataFrame) -> pd.DataFrame:
     ] + ["duration"]
     df = df.reindex(columns=new_columns)
 
-    # Apply the function across rows (axis=1)  
     df = df.apply(generate_duration_statistics, axis=1)
 
     # Cleanup
@@ -185,11 +242,15 @@ def generate_duration_statistics(row):
     return row
 
 
+# TODO, for debugging, remove once finished
 if __name__ == "__main__":
     trace_dir = "data/azure2021/"
     out_dir = "data/traces/reference/preprocessedAzure2021"
     start_time = "00:01:00"
     duration = "100"
+    zero_ms_threshold_percent = "50"
 
-    preprocess_file(trace_dir=trace_dir, start_time=start_time, duration=duration, output_dir=out_dir)
+    log.basicConfig(format='%(levelname)s:%(message)s', level=log.INFO)
+
+    preprocess_file(trace_dir=trace_dir, start_time=start_time, duration=duration, output_dir=out_dir, zero_ms_threshold_percent=zero_ms_threshold_percent)
 

--- a/sampler/preprocess2021.py
+++ b/sampler/preprocess2021.py
@@ -33,10 +33,10 @@ import math
 
 import os
 
-def preprocess_file(trace_dir: str, start_time: str, duration: str, output_dir: str, zero_ms_threshold_percent: str) -> pd.DataFrame:
+def preprocess_file(trace_path: str, start_time: str, duration: str, output_dir: str, zero_ms_threshold_percent: str) -> pd.DataFrame:
     
     # Read CSV
-    trace_file = glob(f"{trace_dir}/AzureFunctionsInvocationTraceForTwoWeeksJan2021.txt")
+    trace_file = glob(f"{trace_path}")
     assert len(trace_file) == 1, "There exists only 1 Azure2021 trace file"
     df = pd.read_csv(trace_file[0])
 

--- a/sampler/preprocess2021.py
+++ b/sampler/preprocess2021.py
@@ -68,7 +68,7 @@ def preprocess_file(trace_dir: str, start_time: str, duration: str, output_dir: 
     mem_df.to_csv(f"{output_dir}/memory.csv", index=False)
     dur_df.to_csv(f"{output_dir}/durations.csv", index=False)
 
-# Filter for invocation from [start_time, start_time+duration_mintues]
+# Filter for invocation from [start_time, start_time+duration_mintues)
 def filter_within_time_interval(df: pd.DataFrame, start_time: str, duration_minutes: str) -> Tuple[pd.DataFrame, pd.Timedelta, pd.Timedelta]:
     
     # Generate start time
@@ -86,7 +86,7 @@ def filter_within_time_interval(df: pd.DataFrame, start_time: str, duration_minu
     interval_end = pd.Timedelta(days=day, hours=hours, minutes=(minutes+duration))
 
     # Get time interval slice
-    df = df[df['start_timestamp'].between(interval_start, interval_end)]
+    df = df[df['start_timestamp'].between(interval_start, interval_end, inclusive="left")]
 
     if (interval_end > pd.Timedelta(days=14, hours=0, minutes=0)):
         log.warning(f"interval_end includes time after 14 days. azure2021 only has 14 days of invocations, ensure start_time and duration entered is intended.")
@@ -192,7 +192,7 @@ def generate_mem_df(df: pd.DataFrame) -> pd.DataFrame:
 
     new_columns = [
         "HashFunction", "HashOwner", "HashApp", "SampleCount", 
-        "AverageAllocatedMb", "AverageAllocatedMb_pct1", "AverageAllocatedMb_pct5", "AverageAllocatedMb_pct25"
+        "AverageAllocatedMb", "AverageAllocatedMb_pct1", "AverageAllocatedMb_pct5", "AverageAllocatedMb_pct25",
         "AverageAllocatedMb_pct50", "AverageAllocatedMb_pct75", "AverageAllocatedMb_pct95", "AverageAllocatedMb_pct99", "AverageAllocatedMb_pct100"
     ] + ["start_timestamp"]
     df = df.reindex(columns=new_columns) 
@@ -201,7 +201,7 @@ def generate_mem_df(df: pd.DataFrame) -> pd.DataFrame:
     df = df.fillna(static_value) # 200MB, based on average stated in Azure2019
 
     # Cleanup
-    df = df.drop(columns=["start_timestamp"])
+    df = df.drop(columns=["start_timestamp", "HashFunction"])
     df["HashOwner"] = 0
 
     return df
@@ -240,17 +240,3 @@ def generate_duration_statistics(row):
     row["percentile_Average_100"] = np.percentile(timestamp_list, 100)
 
     return row
-
-
-# TODO, for debugging, remove once finished
-if __name__ == "__main__":
-    trace_dir = "data/azure2021/"
-    out_dir = "data/traces/reference/preprocessedAzure2021"
-    start_time = "00:01:00"
-    duration = "100"
-    zero_ms_threshold_percent = "50"
-
-    log.basicConfig(format='%(levelname)s:%(message)s', level=log.INFO)
-
-    preprocess_file(trace_dir=trace_dir, start_time=start_time, duration=duration, output_dir=out_dir, zero_ms_threshold_percent=zero_ms_threshold_percent)
-

--- a/sampler/preprocess2021.py
+++ b/sampler/preprocess2021.py
@@ -1,0 +1,195 @@
+#  MIT License
+#
+#  Copyright (c) 2023 EASL and the vHive community
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in all
+#  copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#  SOFTWARE.
+
+from numpy import s_ 
+import pandas as pd
+import logging as log
+import numpy as np
+
+from glob import glob
+from tqdm import tqdm
+from typing import Tuple
+import math
+
+import os
+
+def preprocess_file(trace_dir: str, start_time: str, duration: str, output_dir: str) -> pd.DataFrame:
+    
+    # Read CSV
+    trace_file = glob(f"{trace_dir}/AzureFunctionsInvocationTraceForTwoWeeksJan2021.txt")
+    assert len(trace_file) == 1, "There exists only 1 Azure2021 trace file"
+    df = pd.read_csv(trace_file[0])
+
+    # Keep invocations within interval
+    df, start_td, end_td = time_slice(df, start_time, duration)
+
+    # TODO: Determine if zero duration keep or throw? (see if loader parses correctly.)
+
+    # Validate no NaN
+    df = df.dropna()
+    assert df.isna().sum().sum() == 0
+
+    # Transform into sampler's expected format.
+    inv_df, mem_df, dur_df = transform_to_sampler_format(df, start_td, end_td)
+
+    # Save to directory
+    if not os.path.exists(output_dir):
+        try:
+            os.makedirs(output_dir)
+        except OSError as e:
+            raise RuntimeError(f"Failed to create the output folder: {e}")
+
+    inv_df.to_csv(f"{output_dir}/invocations.csv", index=False)
+    mem_df.to_csv(f"{output_dir}/memory.csv", index=False)
+    dur_df.to_csv(f"{output_dir}/durations.csv", index=False)
+
+def time_slice(df: pd.DataFrame, start_time: str, duration: str) -> Tuple[pd.DataFrame, pd.Timedelta, pd.Timedelta]:
+    
+    # Generate start time
+    df['start_timestamp'] = df['end_timestamp'] - df['duration']
+    df['start_timestamp'] = pd.to_timedelta(df['start_timestamp'], unit='s')
+
+    # Determine time interval
+    start_time = start_time.split(":")
+    day = int(start_time[0])
+    hours = int(start_time[1])
+    minutes = int(start_time[2])
+    duration = int(duration)
+
+    interval_start = pd.Timedelta(days=day, hours=hours, minutes=minutes)
+    interval_end = pd.Timedelta(days=day, hours=hours, minutes=(minutes+duration))
+
+    # Get time interval slice
+    df = df[df['start_timestamp'].between(interval_start, interval_end)]
+
+    return df, interval_start, interval_end
+
+def transform_to_sampler_format(df: pd.DataFrame, interval_start: pd.Timedelta, interval_end: pd.Timedelta
+                                ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    
+    # Determine invocation minute bins
+    start_minute = math.floor((interval_start.total_seconds() / 60))
+    start_minute_bin = start_minute + 1 # Azure2019 starts from minute 1. (invocations in the first minute)
+    
+    end_minute = math.floor((interval_end.total_seconds() / 60))
+    end_minute_bin = end_minute + 1
+
+    # Group into per-func basis
+    df = df.groupby(['app', 'func'])[['start_timestamp', 'duration']].agg(list).reset_index()
+    df = df.rename(columns={'app': 'HashApp', 'func': 'HashFunction'})
+
+    inv_df = generate_inv_df(df, start_minute_bin, end_minute_bin)
+    mem_df = generate_mem_df(df)
+    dur_df = generate_dur_df(df)
+
+    return inv_df, mem_df, dur_df
+    
+def generate_inv_df(df: pd.DataFrame, start_minute_bin: int, end_minute_bin: int) -> pd.DataFrame:
+    
+    # INV_DF Determine invocation data in a per-minute bin-basis
+    # Set new columns, add per-minute bins
+    new_columns = ["HashOwner", "HashApp", "HashFunction", "Trigger"] + list(range(start_minute_bin, end_minute_bin)) + ["start_timestamp"]
+    df = df.reindex(columns=new_columns, fill_value=0) 
+
+    # Apply the function across rows (axis=1)  
+    df = df.apply(bin_timestamps, axis=1)
+
+    # Cleanup
+    df = df.drop(columns=["start_timestamp"])
+    df["Trigger"] = "http"
+    df["HashOwner"] = 0
+
+    return df
+
+def bin_timestamps(row):
+    # Parse timestamps, determine bin
+    timestamp_list = row['start_timestamp']
+    for timestamp in timestamp_list:
+        timestamp_minute_bin = math.floor((timestamp.total_seconds() / 60)) + 1
+
+        # Increment count 
+        row[timestamp_minute_bin] += 1 
+    return row
+
+#TODO: Test
+def generate_mem_df(df: pd.DataFrame) -> pd.DataFrame:
+    new_columns = [
+        "HashFunction", "HashOwner", "HashApp", "SampleCount", 
+        "AverageAllocatedMb", "AverageAllocatedMb_pct1", "AverageAllocatedMb_pct5", "AverageAllocatedMb_pct25"
+        "AverageAllocatedMb_pct50", "AverageAllocatedMb_pct75", "AverageAllocatedMb_pct95", "AverageAllocatedMb_pct99", "AverageAllocatedMb_pct100"
+    ] + ["start_timestamp"]
+    df = df.reindex(columns=new_columns) 
+
+    df['SampleCount'] = df['start_timestamp'].str.len() #TODO: Determine if SampleCount needs a particular value, what reference value to use.
+    df = df.fillna(200.0) # 200MB, based on average stated in Azure2019
+
+    # Cleanup
+    df = df.drop(columns=["start_timestamp"])
+    df["HashOwner"] = 0
+
+    return df
+
+#TODO: Test
+def generate_dur_df(df: pd.DataFrame) -> pd.DataFrame:
+    new_columns = [
+        "HashOwner", "HashApp", "HashFunction", 
+        "Average", "Count", "Minimum", "Maximum",
+        "percentile_Average_0", "percentile_Average_1", "percentile_Average_25", "percentile_Average_50", 
+        "percentile_Average_75", "percentile_Average_99", "percentile_Average_100"
+    ] + ["duration"]
+    df = df.reindex(columns=new_columns)
+
+    # Apply the function across rows (axis=1)  
+    df = df.apply(generate_duration_statistics, axis=1)
+
+    # Cleanup
+    df = df.drop(columns=["duration"])
+    df["HashOwner"] = 0
+
+    return df
+
+def generate_duration_statistics(row):
+    timestamp_list = row['duration']
+
+    row["Average"] = np.mean(timestamp_list)
+    row["Count"] = len(timestamp_list)
+    row["Minimum"] = np.min(timestamp_list)
+    row["Maximum"] = np.max(timestamp_list)
+    row["percentile_Average_0"] = np.percentile(timestamp_list, 0)
+    row["percentile_Average_1"] = np.percentile(timestamp_list, 1)
+    row["percentile_Average_25"] = np.percentile(timestamp_list, 25)
+    row["percentile_Average_50"] = np.percentile(timestamp_list, 50)
+    row["percentile_Average_75"] = np.percentile(timestamp_list, 75)
+    row["percentile_Average_99"] = np.percentile(timestamp_list, 99)
+    row["percentile_Average_100"] = np.percentile(timestamp_list, 100)
+
+    return row
+
+
+if __name__ == "__main__":
+    trace_dir = "data/azure2021/"
+    out_dir = "data/traces/reference/preprocessedAzure2021"
+    start_time = "00:01:00"
+    duration = "100"
+
+    preprocess_file(trace_dir=trace_dir, start_time=start_time, duration=duration, output_dir=out_dir)
+

--- a/sampler/preprocess2021.py
+++ b/sampler/preprocess2021.py
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2023 EASL and the vHive community
+#  Copyright (c) 2026 HySCALE and vHive community
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -33,7 +33,7 @@ import math
 
 import os
 
-def preprocess_file(trace_dir: str, start_time: str, duration: str, output_dir: str, zero_ms_threshold_percent:str) -> pd.DataFrame:
+def preprocess_file(trace_dir: str, start_time: str, duration: str, output_dir: str, zero_ms_threshold_percent: str) -> pd.DataFrame:
     
     # Read CSV
     trace_file = glob(f"{trace_dir}/AzureFunctionsInvocationTraceForTwoWeeksJan2021.txt")

--- a/sampler/preprocess2021.py
+++ b/sampler/preprocess2021.py
@@ -197,16 +197,16 @@ def generate_mem_df(df: pd.DataFrame) -> pd.DataFrame:
     ] + ["start_timestamp"]
     df = df.reindex(columns=new_columns) 
 
-    df['SampleCount'] = df['start_timestamp'].str.len() #TODO: Determine if SampleCount needs a particular value, what reference value to use.
+    df['SampleCount'] = df['start_timestamp'].str.len()
     df = df.fillna(static_value) # 200MB, based on average stated in Azure2019
 
     # Cleanup
-    df = df.drop(columns=["start_timestamp", "HashFunction"])
+    df = df.drop(columns=["start_timestamp"])
     df["HashOwner"] = 0
 
     return df
 
-# Calculate statistics from duration list
+# Calculate statistics from duration list, convert s to ms.
 def generate_dur_df(df: pd.DataFrame) -> pd.DataFrame:
     new_columns = [
         "HashOwner", "HashApp", "HashFunction", 
@@ -226,6 +226,8 @@ def generate_dur_df(df: pd.DataFrame) -> pd.DataFrame:
 
 def generate_duration_statistics(row):
     timestamp_list = row['duration']
+
+    timestamp_list = [s * 1000 for s in timestamp_list] # duration is in ms
 
     row["Average"] = np.mean(timestamp_list)
     row["Count"] = len(timestamp_list)

--- a/sampler/sample.py
+++ b/sampler/sample.py
@@ -252,7 +252,7 @@ def fold_samples(target_sample: Trace, subsample: Trace, original_trace: Trace) 
               f"The subsample to be included\n"
               f"Inv:\n{subsample.inv_df.head()}\n"
               )
-    
+
     inv_df = pd.concat([target_sample.inv_df, subsample.inv_df], ignore_index=True)
     mem_df = pd.concat([target_sample.mem_df, subsample.mem_df], ignore_index=True)
     run_df = pd.concat([target_sample.run_df, subsample.run_df], ignore_index=True)

--- a/sampler/tests/filter_test.py
+++ b/sampler/tests/filter_test.py
@@ -30,10 +30,11 @@ def create_original_df_file(tmp_path, og_df: pd.DataFrame):
 
     dir_path = tmp_path / "og_df"
     dir_path.mkdir()
+    file_path = dir_path / "AzureFunctionsInvocationTraceForTwoWeeksJan2021.txt"
 
-    og_df.to_csv(dir_path / "AzureFunctionsInvocationTraceForTwoWeeksJan2021.txt", index=False)
+    og_df.to_csv(file_path, index=False)
 
-    return str(dir_path)
+    return str(file_path)
 
 def create_sampled_df_file(tmp_path, inv_df: pd.DataFrame):
 
@@ -57,7 +58,7 @@ def test_azure2021_filter(tmp_path):
         # "start_timestamp": [0.50,  5.0, 64.5,  60.0, 200.0]
         }
     )
-    orig_trace_dir = create_original_df_file(tmp_path, og_df)
+    orig_trace_path = create_original_df_file(tmp_path, og_df)
 
     # Sampled DF
     inv_df = pd.DataFrame(
@@ -80,7 +81,7 @@ def test_azure2021_filter(tmp_path):
     duration = 5
     orig_trace_filename = "AzureFunctionsInvocationTraceForTwoWeeksJan2021.txt"
     
-    filter_azure2021(orig_trace_dir, sampled_trace_dir, str(out_dir), start_time, duration, orig_trace_filename)
+    filter_azure2021(orig_trace_path, sampled_trace_dir, str(out_dir), start_time, duration)
 
     # Read and compare output filtered_DF
     filtered_df_path = out_dir / "SampledAzure2021.csv"
@@ -113,7 +114,7 @@ def test_same_app_different_functions(tmp_path):
         # "start_timestamp": [0.50,  5.0, 64.5,  60.0]
         }
     )
-    orig_trace_dir = create_original_df_file(tmp_path, og_df)
+    orig_trace_path = create_original_df_file(tmp_path, og_df)
 
     # Sampled DF
     inv_df = pd.DataFrame(
@@ -135,7 +136,7 @@ def test_same_app_different_functions(tmp_path):
     start_time = "00:00:00"
     duration = 5
     
-    filter_azure2021(orig_trace_dir, sampled_trace_dir, str(out_dir), start_time, duration)
+    filter_azure2021(orig_trace_path, sampled_trace_dir, str(out_dir), start_time, duration)
 
     # Read and compare output filtered_DF
     filtered_df_path = out_dir / "SampledAzure2021.csv"

--- a/sampler/tests/filter_test.py
+++ b/sampler/tests/filter_test.py
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2023 EASL and the vHive community
+#  Copyright (c) 2026 HySCALE and vHive community
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -26,8 +26,28 @@ import logging as log
 from sampler.filter import filter_azure2021
 import os
 
-def create_original_df_file(tmp_path):
+def create_original_df_file(tmp_path, og_df: pd.DataFrame):
 
+    dir_path = tmp_path / "og_df"
+    dir_path.mkdir()
+
+    og_df.to_csv(dir_path / "AzureFunctionsInvocationTraceForTwoWeeksJan2021.txt", index=False)
+
+    return str(dir_path)
+
+def create_sampled_df_file(tmp_path, inv_df: pd.DataFrame):
+
+    dir_path = tmp_path / "sampled_df"
+    dir_path.mkdir()
+
+    inv_df.to_csv(dir_path / "invocations.csv", index=False)
+
+    return str(dir_path)
+
+# Unit happy path test.
+def test_azure2021_filter(tmp_path):
+
+    # Original DF
     og_df = pd.DataFrame(
         {
             "app":           ["aa", "ab", "ac", "ac", "ac"],
@@ -37,16 +57,9 @@ def create_original_df_file(tmp_path):
         # "start_timestamp": [0.50,  5.0, 64.5,  60.0, 200.0]
         }
     )
+    orig_trace_dir = create_original_df_file(tmp_path, og_df)
 
-    dir_path = tmp_path / "og_df"
-    dir_path.mkdir()
-
-    og_df.to_csv(dir_path / "AzureFunctionsInvocationTraceForTwoWeeksJan2021.txt", index=False)
-
-    return str(dir_path)
-
-def create_sampled_df_file(tmp_path):
-
+    # Sampled DF
     inv_df = pd.DataFrame(
         {
             "HashApp":      ["aa", "ab", "ac"],
@@ -60,25 +73,16 @@ def create_sampled_df_file(tmp_path):
             "5":            [0, 0, 0],
         }
     )
+    sampled_trace_dir = create_sampled_df_file(tmp_path, inv_df)
 
-    dir_path = tmp_path / "sampled_df"
-    dir_path.mkdir()
-
-    inv_df.to_csv(dir_path / "invocations.csv", index=False)
-
-    return str(dir_path)
-
-# Unit happy path test.
-def test_azure2021_filter(tmp_path):
-
-    orig_trace_dir = create_original_df_file(tmp_path)
-    sampled_trace_dir = create_sampled_df_file(tmp_path)
     out_dir = tmp_path / "output"
     start_time = "00:00:00"
     duration = 5
+    orig_trace_filename = "AzureFunctionsInvocationTraceForTwoWeeksJan2021.txt"
     
-    filter_azure2021(orig_trace_dir, sampled_trace_dir, str(out_dir), start_time, duration)
+    filter_azure2021(orig_trace_dir, sampled_trace_dir, str(out_dir), start_time, duration, orig_trace_filename)
 
+    # Read and compare output filtered_DF
     filtered_df_path = out_dir / "SampledAzure2021.csv"
     filtered_df = pd.read_csv(filtered_df_path)
 
@@ -89,6 +93,61 @@ def test_azure2021_filter(tmp_path):
             "end_timestamp": [1.00, 10.0, 100.0, 300.0],
             "duration":      [0.50,  5.0,  40.0, 100.0],
         # "start_timestamp": [0.50,  5.0,  60.0, 200.0]
+        }
+    )
+
+    pd.testing.assert_frame_equal(filtered_df, expected_filtered_df)
+
+
+# Azure 2021, 'func' is only unique within an 'app'
+# - Test that same func with different app treated as distinct.
+def test_same_app_different_functions(tmp_path):
+
+    # Original DF
+    og_df = pd.DataFrame(
+        {
+            "app":           ["aa", "ab", "ac",  "ac"],
+            "func":          ["fa", "fb", "fa",  "fb"],
+            "end_timestamp": [1.00, 10.0, 80.0, 100.0], # 5 Minutes, 0-300 seconds
+            "duration":      [0.50,  5.0, 15.5,  40.0],
+        # "start_timestamp": [0.50,  5.0, 64.5,  60.0]
+        }
+    )
+    orig_trace_dir = create_original_df_file(tmp_path, og_df)
+
+    # Sampled DF
+    inv_df = pd.DataFrame(
+        {
+            "HashApp":      ["aa", "ac", "ac"],
+            "HashFunction": ["fa", "fa", "fb"],
+            "HashOwner":    ["oa", "oc", "oc"],
+            "Trigger":      ["tr", "tr", "tr"],
+            "1":            [   1,    0,    0],
+            "2":            [   0,    1,    1],
+            "3":            [   0,    0,    0],
+            "4":            [   0,    0,    0],
+            "5":            [   0,    0,    0],
+        }
+    )
+    sampled_trace_dir = create_sampled_df_file(tmp_path, inv_df)
+
+    out_dir = tmp_path / "output"
+    start_time = "00:00:00"
+    duration = 5
+    
+    filter_azure2021(orig_trace_dir, sampled_trace_dir, str(out_dir), start_time, duration)
+
+    # Read and compare output filtered_DF
+    filtered_df_path = out_dir / "SampledAzure2021.csv"
+    filtered_df = pd.read_csv(filtered_df_path)
+
+    expected_filtered_df = pd.DataFrame(
+        {
+            "app":           ["aa",  "ac",  "ac"],
+            "func":          ["fa",  "fa",  "fb"],
+            "end_timestamp": [1.00,  80.0, 100.0],
+            "duration":      [0.50,  15.5,  40.0],
+        # "start_timestamp": [0.50,  64.5,  60.0]
         }
     )
 

--- a/sampler/tests/filter_test.py
+++ b/sampler/tests/filter_test.py
@@ -1,0 +1,96 @@
+#  MIT License
+#
+#  Copyright (c) 2023 EASL and the vHive community
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in all
+#  copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#  SOFTWARE.
+
+import pandas as pd
+import logging as log
+
+from sampler.filter import filter_azure2021
+import os
+
+def create_original_df_file(tmp_path):
+
+    og_df = pd.DataFrame(
+        {
+            "app":           ["aa", "ab", "ac", "ac", "ac"],
+            "func":          ["fa", "fb", "fc", "fd", "fd"],
+            "end_timestamp": [1.00, 10.0, 80.0, 100.0, 300.0], # 5 Minutes, 0-300 seconds
+            "duration":      [0.50,  5.0, 15.5,  40.0, 100.0],
+        # "start_timestamp": [0.50,  5.0, 64.5,  60.0, 200.0]
+        }
+    )
+
+    dir_path = tmp_path / "og_df"
+    dir_path.mkdir()
+
+    og_df.to_csv(dir_path / "AzureFunctionsInvocationTraceForTwoWeeksJan2021.txt", index=False)
+
+    return str(dir_path)
+
+def create_sampled_df_file(tmp_path):
+
+    inv_df = pd.DataFrame(
+        {
+            "HashApp":      ["aa", "ab", "ac"],
+            "HashFunction": ["fa", "fb", "fd"],
+            "HashOwner":    ["oa", "ob", "oc"],
+            "Trigger":      ["tr", "tr", "tr"],
+            "1":            [1, 1, 0],
+            "2":            [0, 0, 1],
+            "3":            [0, 0, 0],
+            "4":            [0, 0, 1],
+            "5":            [0, 0, 0],
+        }
+    )
+
+    dir_path = tmp_path / "sampled_df"
+    dir_path.mkdir()
+
+    inv_df.to_csv(dir_path / "invocations.csv", index=False)
+
+    return str(dir_path)
+
+# Unit happy path test.
+def test_azure2021_filter(tmp_path):
+
+    orig_trace_dir = create_original_df_file(tmp_path)
+    sampled_trace_dir = create_sampled_df_file(tmp_path)
+    out_dir = tmp_path / "output"
+    start_time = "00:00:00"
+    duration = 5
+    
+    filter_azure2021(orig_trace_dir, sampled_trace_dir, str(out_dir), start_time, duration)
+
+    filtered_df_path = out_dir / "SampledAzure2021.csv"
+    filtered_df = pd.read_csv(filtered_df_path)
+
+    expected_filtered_df = pd.DataFrame(
+        {
+            "app":           ["aa", "ab", "ac", "ac"],
+            "func":          ["fa", "fb", "fd", "fd"],
+            "end_timestamp": [1.00, 10.0, 100.0, 300.0],
+            "duration":      [0.50,  5.0,  40.0, 100.0],
+        # "start_timestamp": [0.50,  5.0,  60.0, 200.0]
+        }
+    )
+
+    pd.testing.assert_frame_equal(filtered_df, expected_filtered_df)
+

--- a/sampler/tests/preprocess2021_test.py
+++ b/sampler/tests/preprocess2021_test.py
@@ -152,3 +152,50 @@ def test_generate_mem_df_fills_static_memory_values():
     mem_df = generate_mem_df(input_df)
 
     pd.testing.assert_frame_equal(mem_df, expected_df)
+
+# Unit happy path test.
+def test_preprocess2021(tmp_path):
+
+    # Original DF
+    og_df = pd.DataFrame(
+        {
+            "app":           ["aa", "ab", "ac",  "ac",  "ac"],
+            "func":          ["fa", "fb", "fc",  "fd",  "fd"],
+            "end_timestamp": [1.00, 10.0, 80.0, 100.0, 300.0], # 5 Minutes, 0-300 seconds
+            "duration":      [0.50,  5.0, 15.5,  40.0, 100.0],
+        # "start_timestamp": [0.50,  5.0, 64.5,  60.0, 200.0]
+        }
+    )
+    dir_path = tmp_path / "og_df"
+    dir_path.mkdir()
+    orig_trace_path = dir_path / "AzureFunctionsInvocationTraceForTwoWeeksJan2021.txt"
+    og_df.to_csv(orig_trace_path, index=False)
+
+    # Test Preprocess2021
+    out_dir = tmp_path / "output"
+    start_time = "00:00:00"
+    duration = 5
+    zero_ms_threshold_percent = 50
+    
+    preprocess_file(dir_path, start_time, str(duration), str(out_dir), str(zero_ms_threshold_percent))
+
+    # Read and compare output preprocessed2021 (inv_df)
+    preprocessed2021_df_path = out_dir / "invocations.csv"
+    preprocessed2021_df = pd.read_csv(preprocessed2021_df_path)
+
+    expected_preprocessed2021_df = pd.DataFrame(
+        {
+            "HashOwner":    [   0,    0,    0,    0],
+            "HashApp":      ["aa", "ab", "ac", "ac"],
+            "HashFunction": ["fa", "fb", "fc", "fd"],
+            "Trigger":      ["http", "http", "http", "http"],
+            "1":            [1, 1, 0, 0],
+            "2":            [0, 0, 1, 1],
+            "3":            [0, 0, 0, 0],
+            "4":            [0, 0, 0, 1],
+            "5":            [0, 0, 0, 0],
+        }
+    )
+
+    pd.testing.assert_frame_equal(preprocessed2021_df, expected_preprocessed2021_df)
+

--- a/sampler/tests/preprocess2021_test.py
+++ b/sampler/tests/preprocess2021_test.py
@@ -25,7 +25,7 @@ import pandas as pd
 import numpy as np
 import pytest
 
-from invitro.sampler.preprocess2021 import (
+from sampler.preprocess2021 import (
     preprocess_file,
     filter_within_time_interval,
     filter_functions_with_0ms_inovcations,
@@ -133,6 +133,7 @@ def test_generate_mem_df_fills_static_memory_values():
     static_value = 200.0
     expected_df = pd.DataFrame(
         {
+            "HashFunction": ["fa", "fb", "fc"],
             "HashOwner":    [   0,    0,    0],
             "HashApp":      ["aa", "ab", "ab"],
             "SampleCount":  [   1,    1,    3],

--- a/sampler/tests/preprocess2021_test.py
+++ b/sampler/tests/preprocess2021_test.py
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2023 EASL and the vHive community
+#  Copyright (c) 2026 HySCALE and vHive community
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -39,18 +39,18 @@ from sampler.preprocess2021 import (
 # Validate [,) interval slicing
 def test_filter_within_time_interval():
     input_df = pd.DataFrame({
-        "app": ["app1", "app2", "app3", "app4"] ,
-        "func": ["f1", "f1", "f2", "f3"],
-        "end_timestamp": [45.0, 70.0, 95.0, 121.0],
-        "duration": [30.0, 10.0, 20.0, 1.0],
-        #"start_timestamp" : [15, 60, 75, 120],
+        "app":           ["app1", "app2", "app3", "app4"],
+        "func":          [  "f1",   "f1",   "f2",   "f3"],
+        "end_timestamp": [  45.0,   70.0,   95.0,  121.0],
+        "duration":      [  30.0,   10.0,   20.0,    1.0],
+        #"start_timestamp":[15, 60, 75, 120],
     })
 
     expected_df = pd.DataFrame({
-        "app": ["app2", "app3"] ,
-        "func": ["f1", "f2"],
-        "end_timestamp": [70.0, 95.0],
-        "duration": [10.0, 20.0],
+        "app":           ["app2", "app3"],
+        "func":          [  "f1",   "f2"],
+        "end_timestamp": [  70.0,   95.0],
+        "duration":      [  10.0,   20.0],
         "start_timestamp": [60, 75],
     })
     expected_df['start_timestamp'] = pd.to_timedelta(expected_df['start_timestamp'], unit='s')

--- a/sampler/tests/preprocess2021_test.py
+++ b/sampler/tests/preprocess2021_test.py
@@ -1,0 +1,153 @@
+#  MIT License
+#
+#  Copyright (c) 2023 EASL and the vHive community
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in all
+#  copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  SOFTWARE.
+
+from pathlib import Path
+
+import pandas as pd
+import numpy as np
+import pytest
+
+from invitro.sampler.preprocess2021 import (
+    preprocess_file,
+    filter_within_time_interval,
+    filter_functions_with_0ms_inovcations,
+    indicate_functions_with_0ms,
+    transform_to_sampler_format,
+    generate_inv_df,
+    generate_mem_df,
+    generate_dur_df,
+)
+
+# Validate [,) interval slicing
+def test_filter_within_time_interval():
+    input_df = pd.DataFrame({
+        "app": ["app1", "app2", "app3", "app4"] ,
+        "func": ["f1", "f1", "f2", "f3"],
+        "end_timestamp": [45.0, 70.0, 95.0, 121.0],
+        "duration": [30.0, 10.0, 20.0, 1.0],
+        #"start_timestamp" : [15, 60, 75, 120],
+    })
+
+    expected_df = pd.DataFrame({
+        "app": ["app2", "app3"] ,
+        "func": ["f1", "f2"],
+        "end_timestamp": [70.0, 95.0],
+        "duration": [10.0, 20.0],
+        "start_timestamp": [60, 75],
+    })
+    expected_df['start_timestamp'] = pd.to_timedelta(expected_df['start_timestamp'], unit='s')
+
+    # Interval of [60, 120)
+    day_hour_minutes = "00:00:01"
+    duration_minutes = "1"
+
+    time_filtered_df, interval_start, interval_end = filter_within_time_interval(input_df, day_hour_minutes, duration_minutes)
+
+    assert interval_start == pd.Timedelta(minutes=1)
+    assert interval_end == pd.Timedelta(minutes=2)
+    pd.testing.assert_frame_equal(time_filtered_df.reset_index(drop=True), expected_df.reset_index(drop=True))
+
+
+# Validate 0ms indicating and counting
+def test_indicate_functions_with_0ms():
+    row = pd.Series({"duration": [0, 0, 10]})
+    result = indicate_functions_with_0ms(row, threshold_percent=50)
+
+    assert result["filter_out"] == 1
+    assert result["total_invocation_count"] == 3
+    
+    row = pd.Series({"duration": [0, 5, 10, 15, 20]})
+    result = indicate_functions_with_0ms(row, threshold_percent=75)
+
+    assert result["filter_out"] == 0
+    assert result["total_invocation_count"] == 5
+
+
+# Bin column generation, invocation binning.
+def test_generate_inv_df_bins():
+    input_df = pd.DataFrame({
+        "HashApp":          ["aa", "ab", "ab"],
+        "HashFunction":     ["fa", "fb", "fc"],
+        "start_timestamp":  [
+            [pd.Timedelta(seconds=60)], 
+            [pd.Timedelta(seconds=90)], 
+            [pd.Timedelta(seconds=120), pd.Timedelta(seconds=150), pd.Timedelta(seconds=180)]
+        ],
+        "duration":         [
+            [10.0],
+            [20.0],   
+            [30.0, 50.0, 70.0],
+        ]
+    })
+
+    expected_df = pd.DataFrame(
+        {
+            "HashOwner":    [   0,    0,    0],
+            "HashApp":      ["aa", "ab", "ab"],
+            "HashFunction": ["fa", "fb", "fc"],
+            "Trigger":      ["http", "http", "http"],
+            2:              [1, 1, 0],
+            3:              [0, 0, 2],
+            4:              [0, 0, 1],
+        }
+    )
+    inv_df = generate_inv_df(input_df, start_minute_bin=2, end_minute_bin=5)
+
+    pd.testing.assert_frame_equal(inv_df, expected_df)
+
+
+def test_generate_mem_df_fills_static_memory_values():
+    input_df = pd.DataFrame({
+        "HashApp":          ["aa", "ab", "ab"],
+        "HashFunction":     ["fa", "fb", "fc"],
+        "start_timestamp":  [
+            [pd.Timedelta(seconds=60)], 
+            [pd.Timedelta(seconds=90)], 
+            [pd.Timedelta(seconds=120), pd.Timedelta(seconds=150), pd.Timedelta(seconds=180)]
+        ],
+        "duration":         [
+            [10.0],
+            [20.0],   
+            [30.0, 50.0, 70.0],
+        ]
+    })
+
+    static_value = 200.0
+    expected_df = pd.DataFrame(
+        {
+            "HashOwner":    [   0,    0,    0],
+            "HashApp":      ["aa", "ab", "ab"],
+            "SampleCount":  [   1,    1,    3],
+            "AverageAllocatedMb":        [static_value, static_value, static_value],
+            "AverageAllocatedMb_pct1":   [static_value, static_value, static_value],
+            "AverageAllocatedMb_pct5":   [static_value, static_value, static_value],
+            "AverageAllocatedMb_pct25":  [static_value, static_value, static_value],
+            "AverageAllocatedMb_pct50":  [static_value, static_value, static_value],
+            "AverageAllocatedMb_pct75":  [static_value, static_value, static_value],
+            "AverageAllocatedMb_pct95":  [static_value, static_value, static_value],
+            "AverageAllocatedMb_pct99":  [static_value, static_value, static_value],
+            "AverageAllocatedMb_pct100": [static_value, static_value, static_value],
+        }
+    )
+
+    mem_df = generate_mem_df(input_df)
+
+    pd.testing.assert_frame_equal(mem_df, expected_df)

--- a/sampler/tests/preprocess2021_test.py
+++ b/sampler/tests/preprocess2021_test.py
@@ -177,7 +177,7 @@ def test_preprocess2021(tmp_path):
     duration = 5
     zero_ms_threshold_percent = 50
     
-    preprocess_file(dir_path, start_time, str(duration), str(out_dir), str(zero_ms_threshold_percent))
+    preprocess_file(orig_trace_path, start_time, str(duration), str(out_dir), str(zero_ms_threshold_percent))
 
     # Read and compare output preprocessed2021 (inv_df)
     preprocessed2021_df_path = out_dir / "invocations.csv"


### PR DESCRIPTION
## Summary

Update Sampler to use Azure2021 function traces.

## Implementation Notes :hammer_and_pick:

Added `preprocessor2021`, transforms azure2021 trace to format usable by `sample`.
Utilize `sample` to generate samples, generating list of functions to keep.
Added `filter`, which notes down the list of functions to keep, and filters the original azure2021 trace, 
keeping the functions in the generated list.

## External Dependencies :four_leaf_clover:

No new python dependencies not already in `requirements.txt` 

## Breaking API Changes :warning:

none (N/A)