### PR TITLE
Bump GitHub Actions to NodeJS 24 versions

### DIFF
--- a/.github/workflows/azure_integration_test.yaml
+++ b/.github/workflows/azure_integration_test.yaml
@@ -57,7 +57,7 @@ jobs:
             ./go.sum
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 

--- a/.github/workflows/e2e_azure.yaml
+++ b/.github/workflows/e2e_azure.yaml
@@ -57,7 +57,7 @@ jobs:
             ./go.sum
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -28,11 +28,11 @@ jobs:
       with:
         lfs: 'true'
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.9'
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       with:
         path: ${{ env.pythonLocation }}
         key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.txt') }}

--- a/.github/workflows/preprocessing_tests.yaml
+++ b/.github/workflows/preprocessing_tests.yaml
@@ -30,11 +30,11 @@ jobs:
         with:
           lfs: 'true'
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.txt') }}

--- a/.github/workflows/tools-tests.yaml
+++ b/.github/workflows/tools-tests.yaml
@@ -53,11 +53,11 @@ jobs:
         with:
           lfs: 'true'
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.9'
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.txt') }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -45,13 +45,13 @@ jobs:
             ./go.mod
             ./go.sum
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.9'
         env:
           PIP_TRUSTED_HOST: "pypi.python.org pypi.org files.pythonhosted.org"
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('tools/trace_synthesizer/requirements.txt') }}
@@ -62,11 +62,11 @@ jobs:
       - name: Build loader
         run: go build cmd/loader.go
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.9'
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.txt') }}


### PR DESCRIPTION
## Summary

Bump workflow actions that use NodeJS 20 to versions using NodeJS 24
Due to future deprecation of NodeJS 20 from GitHub runners. 

## Implementation Notes :hammer_and_pick:

Bump `actions/setup-python` from v5 -> v6
Bump `actions/cache` from v4 -> v5

[GitHub changelog blog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

Below are the previous dependabot PRs for bumping the 2 actions.

https://github.com/vhive-serverless/invitro/pull/687
https://github.com/vhive-serverless/invitro/pull/714

## External Dependencies :four_leaf_clover:

none (N/A)

## Breaking API Changes :warning:

none (N/A)