### PR TITLE
Bump python 3.12 that were missed

### DIFF
--- a/.github/workflows/azure_integration_test.yaml
+++ b/.github/workflows/azure_integration_test.yaml
@@ -56,10 +56,10 @@ jobs:
             ./go.mod
             ./go.sum
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Azure CLI Login Using Service Principal
         run: az login --service-principal --username "$AZURE_APP_ID" --password "$AZURE_PASSWORD" --tenant "$AZURE_TENANT"

--- a/.github/workflows/e2e_azure.yaml
+++ b/.github/workflows/e2e_azure.yaml
@@ -56,10 +56,10 @@ jobs:
             ./go.mod
             ./go.sum
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Azure CLI Login Using Service Principal
         run: az login --service-principal --username "$AZURE_APP_ID" --password "$AZURE_PASSWORD" --tenant "$AZURE_TENANT"

--- a/.github/workflows/preprocessing_tests.yaml
+++ b/.github/workflows/preprocessing_tests.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - uses: actions/cache@v5
         with:

--- a/.github/workflows/tools-tests.yaml
+++ b/.github/workflows/tools-tests.yaml
@@ -55,7 +55,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.12'
 
       - uses: actions/cache@v5
         with:


### PR DESCRIPTION
## Summary
Bump action's python version to 3.12
Is a continuation of [previous PR](https://github.com/vhive-serverless/invitro/pull/763), of which some files were missed. 

## Implementation Notes :hammer_and_pick:
Bump yaml action files of `actions/setup-python@v6` to 3.12

## External Dependencies :four_leaf_clover:
none (N/A)

## Breaking API Changes :warning:
none (N/A)