### PR TITLE
Sampler - Allow sampling of `huawei2023-Private` trace type

### DIFF
--- a/.github/configs/wordlist.txt
+++ b/.github/configs/wordlist.txt
@@ -855,3 +855,8 @@ Kway
 Shen
 Yi
 CloudFormation
+Huawei
+HuaWei
+huawei
+preprocessHuawei
+cmd

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ In-Vitro is a set of tools for analyzing the performance of serverless cluster d
 
 Standard sampled traces are available in [data/traces/reference](data/traces/reference/) folder in this repository. The traces are sampled from the Azure Functions production traces using the [sampler](sampler) tool. More details on the sampling process can be found [here](docs/sampler.md#reference-traces).
 
+## Supported traces
+- [Azure 2019](https://github.com/Azure/AzurePublicDataset/blob/master/AzureFunctionsDataset2019.md)
+- [vSwarm Benchmarks](https://github.com/vhive-serverless/vSwarm)
+- [Azure 2021](https://github.com/Azure/AzurePublicDataset/blob/master/AzureFunctionsInvocationTrace2021.md)
+- [Huawei 2023 Private](https://github.com/sir-lab/data-release/blob/main/README_data_release_2023.md)
+
 ## Reference our work
 
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Standard sampled traces are available in [data/traces/reference](data/traces/ref
 
 ## Supported traces
 - [Azure 2019](https://github.com/Azure/AzurePublicDataset/blob/master/AzureFunctionsDataset2019.md)
-- [vSwarm Benchmarks](https://github.com/vhive-serverless/vSwarm)
 - [Azure 2021](https://github.com/Azure/AzurePublicDataset/blob/master/AzureFunctionsInvocationTrace2021.md)
 - [Huawei 2023 Private](https://github.com/sir-lab/data-release/blob/main/README_data_release_2023.md)
 

--- a/docs/loader.md
+++ b/docs/loader.md
@@ -9,7 +9,6 @@ can choose the APT cluster `d430` node.
 
 ## Supported trace formats
 - Azure2019
-- vSwarm Functions
 - Azure2021
 - Huawei-2023 Private
 

--- a/docs/loader.md
+++ b/docs/loader.md
@@ -7,6 +7,12 @@ A load generator for benchmarking serverless systems.
 The experiments require a server-grade node running Linux (tested on Ubuntu 20, Intel Xeon). On CloudLab, one
 can choose the APT cluster `d430` node.
 
+## Supported trace formats
+- Azure2019
+- vSwarm Functions
+- Azure2021
+- Huawei-2023 Private
+
 ## Create a cluster
 
 ### vHive cluster
@@ -128,12 +134,14 @@ $ tar -xzvf workloads/container/vSwarm_deploy_metadata.tar.gz -C workloads/conta
 This untar the tarball into the `workloads/container/yamls` directory, which contains deployment information and deployment YAML files for all vSwarm benchmarks. If you would like to change some of these deployment files of regenerate them, refer to `generate_deploy_info_docs.md` for an outline of what these deployment files are, and how you can regenerate them.
 
 ## Single execution
-
+### Azure2019
 To run load generator use the following command:
 
 ```bash
 $ go run cmd/loader.go --config cmd/config_knative_trace.json
 ```
+
+### vSwarm
 To run load generator with vSwarm functions based on `mapper_output.json` run the following:
 
 ```bash
@@ -141,6 +149,7 @@ $ go run cmd/loader.go --config cmd/config_vswarm_trace.json
 ```
 To direct the loader to execute vSwarm functions, set the `VSwarm` flag in the loader configuration `true`. For information on how to configure the workload for load generator, please refer to `docs/configuration.md`.
 
+### Azure2021
 To run load generator with Azure2021 functions run the following:
 
 ```bash
@@ -148,6 +157,22 @@ $ go run cmd/loader.go --config cmd/config_knative2021_trace.json
 ```
 To direct the loader to execute Azure2021 dataset functions, set `TracePath` in the loader configuration to the Azure2021 csv file path instead of a directory path. For more information, please refer to [Azure2021 Trace Usage](#azure2021-trace-usage).
 
+### Huawei-2023 Private
+To run `Huawei-2023` functions, the trace must be preprocessed and converted to an equivalent `Azure2019` trace format first. 
+Assuming the `Huawei-2023` dataset is in `data/huawei2023/private_dataset` and is formatted correctly, run the following:
+
+```bash
+# Extract excerpt (100 minutes starting from 1 hr) and convert
+$ python -m sampler preprocessHuawei2023 -t data/huawei2023/private_dataset -o data/huawei2023/output -s 00:01:00 -dur 100
+
+# Run as Azure2019, Ensure to modify 'TracePath' in the .json to 'data/huawei2023/output'
+$ go run cmd/loader.go --config cmd/config_knative_trace.json
+```
+
+For more information about this conversion, the expected directory format of `private_dataset`, as well as instructions on sub-sampling the trace.
+Please refer to the [Huawei-2023 sampler documentation](sampler.md#using-huawei-2023-traces) in `sampler.md`.
+
+### Additional settings
 Additionally, one can specify log verbosity argument as `--verbosity [info, debug, trace]`. The default value is `info`.
 
 To execute in a dry run mode without generating any load, set the `--dry-run` flag to `true`. This is useful for testing and validating configurations without executing actual requests.

--- a/docs/sampler.md
+++ b/docs/sampler.md
@@ -206,10 +206,56 @@ and extract the CSV files (default location: `data/azure2021/`).
 
 The following is an example usage of the sampler:
 
-```console
+``` bash
 python -m sampler preprocess2021 -t data/azure2021/original_trace_filename.txt -o data/traces/reference/preprocessed_azure2021 -s 00:01:00 -dur 100 -thresh 50
 
 python -m sampler sample -t data/traces/reference/preprocessed_azure2021 -orig data/traces/reference/preprocessed_azure2021 -o data/traces/reference/sampled_azure2021 -min 20 -st 5 -max 45 -tr 16
 
 python -m sampler filter2021 -t data/azure2021/original_trace_filename.txt -st data/traces/reference/sampled_azure2021/samples/40 -o data/traces/reference/filtered2021 -s 00:01:00 -dur 100
 ```
+
+## Using Hua-Wei-2023 Traces
+### Overview
+Conceptually, Hua-Wei-2023-Private trace is transformed into Azure2019 format in `preprocessHuawei2023`. 
+It can then be treated as Azure2019 format for Sampler and Loader.
+
+Sampling Hua-Wei-2023 trace follows 2 steps: 
+1. Pre-process the original trace (`huawei2023private`) -> cleaned Azure2019 format.
+2. Run the sampler on cleaned trace (`sampler`) -> sub-sampled Azure2019 format.
+
+### Workflow
+Firstly, download the original Hua-Wei-2023-Private dataset from the [Hua-Wei-2023 github repo](https://github.com/sir-lab/data-release/blob/main/README_data_release_2023.md). (default location: `data/huawei2023/`).
+
+The folder structure follows the structure recommended in the above repo.
+A condensed version is shown below: 
+```bash
+data/huawei2023/
+├── private_dataset
+    ├── function_delay_minute
+    │   ├── day_000.csv
+    │   ├── ...
+    │   └── day_234.csv
+    ├── memory_limit_minute
+    │   ├── day_000.csv
+    │   ├── ...
+    │   └── day_234.csv
+    └── requests_minute
+        ├── day_000.csv
+        ├── ...
+        └── day_234.csv
+```
+
+Example usage of sampler:
+```bash
+# Preprocess
+`python -m sampler preprocessHuawei2023 -t data/huawei2023/private_dataset -o data/huawei2023/output -s 00:01:00 -dur 100`
+# Sample
+`python -m sampler sample -t data/huawei2023/output -orig data/huawei2023/output -o data/huawei2023/output/sampled -min 20 -st 10 -max 80 -tr 16`
+```
+
+### Preprocess Hua-Wei-2023 
+
+The preprocessing follows 3 steps:
+1. Filter for invocations within user supplied time interval.
+2. Calculate percentile statistics for `run_df` and `mem_df` using non-zero data points within the time interval.
+3. Transform the trace to azure2019 format. 

--- a/docs/sampler.md
+++ b/docs/sampler.md
@@ -221,7 +221,7 @@ It can then be treated as Azure2019 format for Sampler and Loader.
 
 Sampling Hua-Wei-2023 trace follows 2 steps: 
 1. Pre-process the original trace (`huawei2023private`) -> cleaned Azure2019 format.
-2. Run the sampler on cleaned trace (`sampler`) -> sub-sampled Azure2019 format.
+2. Run the sampler on cleaned trace (`sampler`), specify new res_norm_factor -> sub-sampled Azure2019 format.
 
 ### Workflow
 Firstly, download the original Hua-Wei-2023-Private dataset from the [Hua-Wei-2023 github repo](https://github.com/sir-lab/data-release/blob/main/README_data_release_2023.md). (default location: `data/huawei2023/`).
@@ -246,11 +246,12 @@ data/huawei2023/
 ```
 
 Example usage of sampler:
+A '-res' value of 1,000,000 was found empirically as mean of dataset of non-NAN values. (memory: 4000, duration: 250 -> product: 1,000,000)
 ```bash
 # Preprocess
 `python -m sampler preprocessHuawei2023 -t data/huawei2023/private_dataset -o data/huawei2023/output -s 00:01:00 -dur 100`
 # Sample
-`python -m sampler sample -t data/huawei2023/output -orig data/huawei2023/output -o data/huawei2023/output/sampled -min 20 -st 10 -max 80 -tr 16`
+`python -m sampler sample -t data/huawei2023/output -orig data/huawei2023/output -o data/huawei2023/output/sampled -min 20 -st 10 -max 80 -tr 16 -res 1000000`
 ```
 
 ### Preprocess Hua-Wei-2023 

--- a/docs/sampler.md
+++ b/docs/sampler.md
@@ -214,17 +214,17 @@ python -m sampler sample -t data/traces/reference/preprocessed_azure2021 -orig d
 python -m sampler filter2021 -t data/azure2021/original_trace_filename.txt -st data/traces/reference/sampled_azure2021/samples/40 -o data/traces/reference/filtered2021 -s 00:01:00 -dur 100
 ```
 
-## Using Hua-Wei-2023 Traces
+## Using Huawei-2023 Traces
 ### Overview
-Conceptually, Hua-Wei-2023-Private trace is transformed into Azure2019 format in `preprocessHuawei2023`. 
+Conceptually, Huawei-2023-Private trace is transformed into Azure2019 format in `preprocessHuawei2023`. 
 It can then be treated as Azure2019 format for Sampler and Loader.
 
-Sampling Hua-Wei-2023 trace follows 2 steps: 
+Sampling Huawei-2023 trace follows 2 steps: 
 1. Pre-process the original trace (`huawei2023private`) -> cleaned Azure2019 format.
 2. Run the sampler on cleaned trace (`sampler`), specify new res_norm_factor -> sub-sampled Azure2019 format.
 
 ### Workflow
-Firstly, download the original Hua-Wei-2023-Private dataset from the [Hua-Wei-2023 github repo](https://github.com/sir-lab/data-release/blob/main/README_data_release_2023.md). (default location: `data/huawei2023/`).
+Firstly, download the original Huawei-2023-Private dataset from the [Huawei-2023 github repo](https://github.com/sir-lab/data-release/blob/main/README_data_release_2023.md). (default location: `data/huawei2023/`).
 
 The folder structure follows the structure recommended in the above repo.
 A condensed version is shown below: 
@@ -254,7 +254,7 @@ A '-res' value of 1,000,000 was found empirically as mean of dataset of non-NAN 
 `python -m sampler sample -t data/huawei2023/output -orig data/huawei2023/output -o data/huawei2023/output/sampled -min 20 -st 10 -max 80 -tr 16 -res 1000000`
 ```
 
-### Preprocess Hua-Wei-2023 
+### Preprocess Huawei-2023 
 
 The preprocessing follows 3 steps:
 1. Filter for invocations within user supplied time interval.

--- a/sampler/__main__.py
+++ b/sampler/__main__.py
@@ -97,7 +97,7 @@ def run(args):
         generate_samples(inv_df=inv_df, mem_df=mem_df, run_df=run_df,
                          inv_df_orig=inv_df_orig, mem_df_orig=mem_df_orig, run_df_orig=run_df_orig,
                          min_size=args.min_size, step=args.step_size, max_size=args.max_size,
-                         trial_num=args.trial_num,
+                         trial_num=args.trial_num, res_norm=args.res_norm,
                          out_path=args.output)
 
     if args.cmd == 'plot':
@@ -180,6 +180,15 @@ def main():
         default=16,
         metavar='integer',
         help='Number of sampling trials for each sample size.'
+    )
+
+    sample_parser.add_argument(
+        '-res',
+        '--res-norm',
+        required=False,
+        type=int,
+        metavar='integer',
+        help='Normalisation factor between invocation and resources distribution. (divides resources by this value, to balance Wasserstein distance calculation)'
     )
 
     ####################################################

--- a/sampler/__main__.py
+++ b/sampler/__main__.py
@@ -25,12 +25,14 @@ import argparse
 import logging as log
 import os
 import sys
+import trace
 import pandas as pd
 
 # from sampler.plot import plot_cdf
 from sampler.preprocess import parse_trace_files
 from sampler.sample import generate_samples
 from sampler.preprocess2021 import preprocess_file
+from sampler.preprocessHuawei import preprocess_huawei
 from sampler.filter import filter_azure2021
 
 log.basicConfig(format='%(levelname)s:%(message)s', level=log.INFO)
@@ -69,6 +71,11 @@ def run(args):
     if args.cmd == 'preprocess2021':
         preprocess_file(trace_path=args.trace, start_time=args.start, duration=args.duration, 
                         output_dir=args.output, zero_ms_threshold_percent=args.threshold)
+        return
+    
+    if args.cmd == 'preprocessHuawei2023':
+        preprocess_huawei(trace_dir=args.trace, start_time=args.start, duration=args.duration, 
+                        output_dir=args.output)
         return
     
     if args.cmd == 'filter2021':
@@ -335,7 +342,44 @@ def main():
     )
 
     ####################################################
+    # Huawei2023 Private
 
+    huwawei2023private_parser = subparser.add_parser('preprocessHuawei2023')
+
+    huwawei2023private_parser.add_argument(
+        '-t',
+        '--trace',
+        required=True,
+        metavar='path',
+        help='Directory path containing the huawei2023private trace. ' \
+        'This directory should have each of the trace metric in a distinct named subfolder. (`function_delay_minute`, `requests_minute`)'
+    )
+
+    huwawei2023private_parser.add_argument(
+        '-s',
+        '--start',
+        required=True,
+        metavar='start',
+        help='Time in dd:hh:mm format, at which the excerpt of the trace should begin, first day is day 0'
+    )
+
+    huwawei2023private_parser.add_argument(
+        '-dur',
+        '--duration',
+        required=True,
+        metavar='duration',
+        help='Duration in minutes to extract from the trace'
+    )
+
+    huwawei2023private_parser.add_argument(
+        '-o',
+        '--output',
+        required=True,
+        metavar='out_path',
+        help='Directory path of the preprocessed traces'
+    )
+
+    ####################################################
 
     args = parser.parse_args()
 

--- a/sampler/preprocessHuawei.py
+++ b/sampler/preprocessHuawei.py
@@ -24,6 +24,7 @@ import pandas as pd
 import logging as log
 import numpy as np
 from pathlib import Path
+from typing import Tuple
 
 def preprocess_huawei(trace_dir: str, start_time: str, duration: str, output_dir: str, zero_ms_threshold_percent: str) -> pd.DataFrame:
     
@@ -81,8 +82,8 @@ def preprocess_huawei(trace_dir: str, start_time: str, duration: str, output_dir
     
     return
 
-
-def generate_inv_df(requests_minute_df: pd.DataFrame) -> pd.DataFrame: # Honestly creating test will make me more confident
+# Count of invocations per minute. Filters out functions with 0 invocations.
+def generate_inv_df(requests_minute_df: pd.DataFrame) -> pd.DataFrame:
 
     # Make columns into minute bins
     df = requests_minute_df.drop(columns='day')
@@ -138,7 +139,10 @@ def generate_mem_df(memory_limit_minute: pd.DataFrame) -> pd.DataFrame:
     df["AverageAllocatedMb_pct75"] = min_bin_df.quantile(0.75, axis=1)
     df["AverageAllocatedMb_pct95"] = min_bin_df.quantile(0.95, axis=1)
     df["AverageAllocatedMb_pct99"] = min_bin_df.quantile(0.99, axis=1)
-    df["AverageAllocatedMb_pct100"] = min_bin_df.quantile(1.00, axis=1)    
+    df["AverageAllocatedMb_pct100"] = min_bin_df.quantile(1.00, axis=1)
+
+    # Filter out zero allocated memory
+    df = df.loc[df["SampleCount"] != 0]
 
     # Cleanup - Keep only required columns
     column_order = [
@@ -180,6 +184,9 @@ def generate_dur_df(function_delay_minute: pd.DataFrame) -> pd.DataFrame:
     df["percentile_Average_99"] = min_bin_df.quantile(0.99, axis=1)
     df["percentile_Average_100"] = min_bin_df.quantile(1.00, axis=1)
 
+    # Filter out zero duration
+    df = df.loc[df["Count"] != 0]
+
     # Cleanup - Keep only required columns
     new_columns = [
         "HashFunction", "HashOwner", "HashApp",  
@@ -191,8 +198,30 @@ def generate_dur_df(function_delay_minute: pd.DataFrame) -> pd.DataFrame:
 
     return df
 
-def filter_out_functions_with_zero_invocations():
-    return 1
+# Filter for functions that appear in all 3 dfs.
+def get_intersection(
+        inv_df: pd.DataFrame, mem_df: pd.DataFrame, run_df: pd.DataFrame
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    
+    # Matches cols that are same across all 3 DFs
+    cols = ['HashApp', 'HashFunction']
+    common_idx = (
+        inv_df.set_index(cols).index
+        .intersection(mem_df.set_index(cols).index)
+        .intersection(run_df.set_index(cols).index)
+    )
+
+    inv_df_cleaned = inv_df.set_index(cols).loc[common_idx].reset_index()
+    mem_df_cleaned = mem_df.set_index(cols).loc[common_idx].reset_index()
+    run_df_cleaned = run_df.set_index(cols).loc[common_idx].reset_index()
+
+    log.debug(f"inv_df row count after intersection: {len(inv_df)}")
+    log.debug(f"mem_df row count after intersection: {len(mem_df)}")
+    log.debug(f"run_df row count after intersection: {len(run_df)}")
+    
+    return inv_df_cleaned, mem_df_cleaned, run_df_cleaned
+
+    # Leaves only rows with the common HashApp and HashFunction values in all 3 dfs
 
 if __name__ == "__main__":
 

--- a/sampler/preprocessHuawei.py
+++ b/sampler/preprocessHuawei.py
@@ -26,43 +26,15 @@ import numpy as np
 from pathlib import Path
 from typing import Tuple
 
-def preprocess_huawei(trace_dir: str, start_time: str, duration: str, output_dir: str, zero_ms_threshold_percent: str) -> pd.DataFrame:
+def preprocess_huawei(trace_dir: str, start_time: str, duration: str, output_dir: str) -> pd.DataFrame:
     
-    # Time interval filter // Allow cross day filtering?
-    start_time = start_time.split(":")
-    day = int(start_time[0])
-    hours = int(start_time[1])
-    minutes = int(start_time[2])
-    duration = int(duration)
-
-    # Determine time interval
-    td_interval_start = pd.Timedelta(days=day, hours=hours, minutes=minutes)
-    td_interval_end = pd.Timedelta(days=day, hours=hours, minutes=(minutes+duration))
-    starting_day = td_interval_start.days
-    ending_day = td_interval_end.days
-
-    # Read all metrics within time interval
-    metrics = {
+    # Read CSVs
+    metrics_to_read = {
         "function_delay_minute": {"path": Path("function_delay_minute"), "df": pd.DataFrame()},
         "memory_limit_minute": {"path": Path("memory_limit_minute"), "df": pd.DataFrame()},
-        "memory_usage_minute": {"path": Path("memory_usage_minute"), "df": pd.DataFrame()},
         "requests_minute": {"path": Path("function_delay_minute"), "df": pd.DataFrame()},
     }
-    for metric, value in metrics.items():
-        directory = Path(trace_dir) / value["path"]
-        final_df = pd.DataFrame()
-
-        # Determine files to read
-        for day in range(starting_day, ending_day + 1):
-            file_path = directory / f"day_{day:03d}.csv" # Leading zeros, width of 3 (001, 002)
-            df = pd.read_csv(file_path)
-
-            # Filter by timestamp
-            df = df[df["time"].between(td_interval_start.seconds, td_interval_end.seconds, inclusive='left')] # left <= series < right
-
-            final_df = pd.concat([final_df, df], ignore_index=True)
-
-        value["df"] = final_df
+    metrics = read_all_trace_csv(trace_dir, start_time, duration, metrics_to_read)
 
     # Transform to sampler format (inv_df, mem_df, run_df)
     # All generation filters out zero/NaN values
@@ -81,6 +53,41 @@ def preprocess_huawei(trace_dir: str, start_time: str, duration: str, output_dir
     dur_df.to_csv(output_dir / "durations.csv", index=False)
     
     return
+
+def read_all_trace_csv(trace_dir: str, start_time: str, duration: str, metrics: dict[str, dict[str, pd.DataFrame]]) -> dict[str, dict[str, pd.DataFrame]]:
+
+    # Time interval filter
+    start_time = start_time.split(":")
+    day = int(start_time[0])
+    hours = int(start_time[1])
+    minutes = int(start_time[2])
+    duration = int(duration)
+
+    # Determine time interval
+    td_interval_start = pd.Timedelta(days=day, hours=hours, minutes=minutes)
+    td_interval_end = pd.Timedelta(days=day, hours=hours, minutes=(minutes+duration))
+    starting_day = td_interval_start.days
+    ending_day = td_interval_end.days
+
+    # Read all metrics within time interval
+    for metric, value in metrics.items():
+        directory = Path(trace_dir) / value["path"]
+        final_df = pd.DataFrame()
+
+        # Determine files to read
+        for day in range(starting_day, ending_day + 1):
+            file_path = directory / f"day_{day:03d}.csv" # Leading zeros, width of 3 (001, 002)
+            df = pd.read_csv(file_path)
+
+            # Filter by timestamp
+            df = df[df["time"].between(td_interval_start.total_seconds(), td_interval_end.total_seconds(), inclusive='left')] # left <= series < right
+
+            final_df = pd.concat([final_df, df], ignore_index=True)
+
+        value["df"] = final_df
+
+    return metrics
+
 
 # Count of invocations per minute. Filters out functions with 0 invocations.
 def generate_inv_df(requests_minute_df: pd.DataFrame) -> pd.DataFrame:
@@ -108,7 +115,7 @@ def generate_inv_df(requests_minute_df: pd.DataFrame) -> pd.DataFrame:
     minute_bin_columns = df.columns[4:]
     df = df.dropna(subset=minute_bin_columns, how='all')
 
-    log.info(f"Inv df removed uninvoked functions (before -> after): {len(prefiltered_df)} -> {len(df)}")
+    log.info(f"inv_df removed uninvoked functions (before -> after): {len(prefiltered_df)} -> {len(df)}")
 
     # Set 0 invocations from NaN to 0.
     df = df.fillna(0)
@@ -151,7 +158,9 @@ def generate_mem_df(memory_limit_minute: pd.DataFrame) -> pd.DataFrame:
     df["AverageAllocatedMb_pct100"] = min_bin_df.quantile(1.00, axis=1)
 
     # Filter out zero allocated memory
+    prefiltered_df = df
     df = df.loc[df["SampleCount"] != 0]
+    log.info(f"mem_df removed unallocated functions (before -> after): {len(prefiltered_df)} -> {len(df)}")
 
     # Cleanup - Keep only required columns
     column_order = [
@@ -197,7 +206,9 @@ def generate_dur_df(function_delay_minute: pd.DataFrame) -> pd.DataFrame:
     df["percentile_Average_100"] = min_bin_df.quantile(1.00, axis=1)
 
     # Filter out zero duration
+    prefiltered_df = df
     df = df.loc[df["Count"] != 0]
+    log.info(f"dur_df removed functions without duration (before -> after): {len(prefiltered_df)} -> {len(df)}")
 
     # Cleanup - Keep only required columns
     new_columns = [
@@ -217,7 +228,7 @@ def get_intersection(
         inv_df: pd.DataFrame, mem_df: pd.DataFrame, run_df: pd.DataFrame
 ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     
-    # Matches cols that are same across all 3 DFs
+    # Matches cols that are same App and Function across all 3 DFs 
     cols = ['HashApp', 'HashFunction']
     common_idx = (
         inv_df.set_index(cols).index
@@ -229,19 +240,11 @@ def get_intersection(
     mem_df_cleaned = mem_df.set_index(cols).loc[common_idx].reset_index()
     run_df_cleaned = run_df.set_index(cols).loc[common_idx].reset_index()
 
-    log.info(f"inv_df row count after intersection: {len(inv_df)}")
-    log.info(f"mem_df row count after intersection: {len(mem_df)}")
-    log.info(f"run_df row count after intersection: {len(run_df)}")
+    log.info(f"Keep only functions that appear in all DFs:")
+    log.info(f"inv_df keep common functions: {len(inv_df)} -> {len(inv_df_cleaned)}")
+    log.info(f"mem_df keep common functions: {len(mem_df)} -> {len(mem_df_cleaned)}")
+    log.info(f"run_df keep common functions: {len(run_df)} -> {len(run_df_cleaned)}")
     
     return inv_df_cleaned, mem_df_cleaned, run_df_cleaned
 
-    # Leaves only rows with the common HashApp and HashFunction values in all 3 dfs
 
-if __name__ == "__main__":
-
-    trace_dir = "../Huawei2023/private_dataset"
-    start_time = "00:00:30"  # DD:HH:MM 
-    duration = 5             # Minutes
-    output_dir = "../Huawei2023/output"
-    
-    preprocess_huawei(trace_dir, start_time, duration, output_dir, 0)

--- a/sampler/preprocessHuawei.py
+++ b/sampler/preprocessHuawei.py
@@ -1,0 +1,93 @@
+#  MIT License
+#
+#  Copyright (c) 2026 HySCALE and vHive community
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in all
+#  copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#  SOFTWARE.
+
+import pandas as pd
+import logging as log
+import numpy as np
+from pathlib import Path
+
+
+def preprocess_huawei(trace_dir: str, start_time: str, duration: str, output_dir: str, zero_ms_threshold_percent: str) -> pd.DataFrame:
+    
+    # Time interval filter // Allow cross day filtering?
+    start_time = start_time.split(":")
+    day = int(start_time[0])
+    hours = int(start_time[1])
+    minutes = int(start_time[2])
+    duration = int(duration)
+
+    # Determine time interval
+    td_interval_start = pd.Timedelta(days=day, hours=hours, minutes=minutes)
+    td_interval_end = pd.Timedelta(days=day, hours=hours, minutes=(minutes+duration))
+    starting_day = td_interval_start.days
+    ending_day = td_interval_end.days
+
+    # Read all metrics within time interval
+    metrics = {
+        "function_delay_minute": {"path": Path("function_delay_minute"), "df": pd.DataFrame()},
+        "memory_limit_minute": {"path": Path("memory_limit_minute"), "df": pd.DataFrame()},
+        "memory_usage_minute": {"path": Path("memory_usage_minute"), "df": pd.DataFrame()},
+        "requests_minute": {"path": Path("function_delay_minute"), "df": pd.DataFrame()},
+    }
+    for metric, value in metrics.items():
+        directory = Path(trace_dir) / value["path"]
+        final_df = pd.DataFrame()
+
+        # Determine files to read
+        for day in range(starting_day, ending_day + 1):
+            file_path = directory / f"day_{day:03d}.csv" # Leading zeros, width of 3 (001, 002)
+            df = pd.read_csv(file_path)
+
+            # Filter by timestamp
+            df = df[df["time"].between(td_interval_start.seconds, td_interval_end.seconds, inclusive='left')] # left <= series < right
+
+            final_df = pd.concat([final_df, df], ignore_index=True)
+
+        value["df"] = final_df
+
+    # Transform to sampler format (inv_df, mem_df, run_df)
+    # All generation filters out zero/NaN values
+    inv_df = generate_inv_df(metrics["requests_minute"]["df"])
+    mem_df = generate_mem_df(metrics["memory_limit_minute"]["df"])
+    dur_df = generate_dur_df(metrics["function_delay_minute"]["df"])
+
+    inv_df, mem_df, dur_df = get_intersection(inv_df, mem_df, dur_df)
+
+    # Save to output
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    
+    inv_df.to_csv(output_dir / "invocations.csv", index=False)
+    mem_df.to_csv(output_dir / "memory.csv", index=False)
+    dur_df.to_csv(output_dir / "durations.csv", index=False)
+    
+    return
+
+
+if __name__ == "__main__":
+
+    trace_dir = "..\Huawei2023\private_dataset"
+    start_time = "00:00:30"  # DD:HH:MM 
+    duration = 5             # Minutes
+    output_dir = "..\Huawei2023\output"
+    
+    preprocess_huawei(trace_dir, start_time, duration, output_dir, 0)

--- a/sampler/preprocessHuawei.py
+++ b/sampler/preprocessHuawei.py
@@ -25,7 +25,6 @@ import logging as log
 import numpy as np
 from pathlib import Path
 
-
 def preprocess_huawei(trace_dir: str, start_time: str, duration: str, output_dir: str, zero_ms_threshold_percent: str) -> pd.DataFrame:
     
     # Time interval filter // Allow cross day filtering?
@@ -83,11 +82,123 @@ def preprocess_huawei(trace_dir: str, start_time: str, duration: str, output_dir
     return
 
 
+def generate_inv_df(requests_minute_df: pd.DataFrame) -> pd.DataFrame: # Honestly creating test will make me more confident
+
+    # Make columns into minute bins
+    df = requests_minute_df.drop(columns='day')
+    df['time'] = df['time']/60 + 1 # inv_df starts from minute 1
+    df = df.set_index('time', drop=True)
+    df = df.T
+
+    # Add in front 4 columns
+    front_cols = ["HashOwner", "HashApp", "HashFunction", "Trigger"]
+    empty_front_df = pd.DataFrame(columns=front_cols, index=df.index)
+    df = pd.concat([empty_front_df, df], axis=1)
+
+    df["HashOwner"] = 0
+    df['HashApp'] = df.index
+    df['HashFunction'] = df.index
+    df["Trigger"] = "http"
+
+    # Filter out functions with 0 invocations
+    minute_bin_columns = df.columns[4:]
+    df = df.dropna(subset=minute_bin_columns, how='all')
+
+    # Set 0 invocations from NaN to 0.
+    df = df.fillna(0)
+
+    return df
+
+# Memory is total function footprint -> allocated memory across all pods for a single function.
+def generate_mem_df(memory_limit_minute: pd.DataFrame) -> pd.DataFrame:
+    
+    # Make columns into minute bins
+    df = memory_limit_minute.drop(columns='day')
+    df['time'] = df['time']/60 + 1 # inv_df starts from minute 1
+    df = df.set_index('time', drop=True)
+    df = df.T
+
+    minute_bin_columns = df.columns
+    min_bin_df = df[minute_bin_columns]
+
+    # Set IDs
+    df["HashFunction"] = df.index
+    df["HashOwner"] = 0
+    df['HashApp'] = df.index
+
+    # Sample count is estimated as count of non-NAN samples
+    df["SampleCount"] = min_bin_df.count(axis=1)
+
+    # Calculate percentiles from non-NAN datapoints within time interval
+    df["AverageAllocatedMb"] = min_bin_df.mean(axis=1)
+    df["AverageAllocatedMb_pct1"] = min_bin_df.quantile(0.01, axis=1)
+    df["AverageAllocatedMb_pct5"] = min_bin_df.quantile(0.05, axis=1)
+    df["AverageAllocatedMb_pct25"] = min_bin_df.quantile(0.25, axis=1)
+    df["AverageAllocatedMb_pct50"] = min_bin_df.quantile(0.50, axis=1)
+    df["AverageAllocatedMb_pct75"] = min_bin_df.quantile(0.75, axis=1)
+    df["AverageAllocatedMb_pct95"] = min_bin_df.quantile(0.95, axis=1)
+    df["AverageAllocatedMb_pct99"] = min_bin_df.quantile(0.99, axis=1)
+    df["AverageAllocatedMb_pct100"] = min_bin_df.quantile(1.00, axis=1)    
+
+    # Cleanup - Keep only required columns
+    column_order = [
+        "HashFunction", "HashOwner", "HashApp", "SampleCount", 
+        "AverageAllocatedMb", "AverageAllocatedMb_pct1", "AverageAllocatedMb_pct5", "AverageAllocatedMb_pct25",
+        "AverageAllocatedMb_pct50", "AverageAllocatedMb_pct75", "AverageAllocatedMb_pct95", "AverageAllocatedMb_pct99", "AverageAllocatedMb_pct100"
+    ]
+    df = df.reindex(columns=column_order)
+
+    return df
+
+# Duration is function execution time averaged over all pods, timestamped in minute basis
+def generate_dur_df(function_delay_minute: pd.DataFrame) -> pd.DataFrame:
+
+    # Make columns into minute bins
+    df = function_delay_minute.drop(columns='day')
+    df['time'] = df['time']/60 + 1 # inv_df starts fro#m minute 1
+    df = df.set_index('time', drop=True)
+    df = df.T
+
+    minute_bin_columns = df.columns
+    min_bin_df = df[minute_bin_columns]
+
+    # Set IDs
+    df["HashOwner"] = 0
+    df['HashApp'] = df.index
+    df["HashFunction"] = df.index
+
+    # Generate stats (derived from datapoints within time interval)
+    df["Average"] = min_bin_df.mean(axis=1)
+    df["Count"] = min_bin_df.count(axis=1)
+    df["Minimum"] = min_bin_df.min(axis=1)
+    df["Maximum"] = min_bin_df.max(axis=1)
+    df["percentile_Average_0"] = min_bin_df.quantile(0.00, axis=1)
+    df["percentile_Average_1"] = min_bin_df.quantile(0.01, axis=1)
+    df["percentile_Average_25"] = min_bin_df.quantile(0.25, axis=1)
+    df["percentile_Average_50"] = min_bin_df.quantile(0.50, axis=1)
+    df["percentile_Average_75"] = min_bin_df.quantile(0.75, axis=1)
+    df["percentile_Average_99"] = min_bin_df.quantile(0.99, axis=1)
+    df["percentile_Average_100"] = min_bin_df.quantile(1.00, axis=1)
+
+    # Cleanup - Keep only required columns
+    new_columns = [
+        "HashFunction", "HashOwner", "HashApp",  
+        "Average", "Count", "Minimum", "Maximum",
+        "percentile_Average_0", "percentile_Average_1", "percentile_Average_25", "percentile_Average_50", 
+        "percentile_Average_75", "percentile_Average_99", "percentile_Average_100"
+    ]
+    df = df.reindex(columns=new_columns)
+
+    return df
+
+def filter_out_functions_with_zero_invocations():
+    return 1
+
 if __name__ == "__main__":
 
-    trace_dir = "..\Huawei2023\private_dataset"
+    trace_dir = "../Huawei2023/private_dataset"
     start_time = "00:00:30"  # DD:HH:MM 
     duration = 5             # Minutes
-    output_dir = "..\Huawei2023\output"
+    output_dir = "../Huawei2023/output"
     
     preprocess_huawei(trace_dir, start_time, duration, output_dir, 0)

--- a/sampler/preprocessHuawei.py
+++ b/sampler/preprocessHuawei.py
@@ -88,6 +88,7 @@ def generate_inv_df(requests_minute_df: pd.DataFrame) -> pd.DataFrame:
     # Make columns into minute bins
     df = requests_minute_df.drop(columns='day')
     df['time'] = df['time']/60 + 1 # inv_df starts from minute 1
+    df['time'] = df['time'].astype(int).astype(str) # 1.0 -> 1
     df = df.set_index('time', drop=True)
     df = df.T
 
@@ -96,17 +97,24 @@ def generate_inv_df(requests_minute_df: pd.DataFrame) -> pd.DataFrame:
     empty_front_df = pd.DataFrame(columns=front_cols, index=df.index)
     df = pd.concat([empty_front_df, df], axis=1)
 
-    df["HashOwner"] = 0
+    df["HashOwner"] = "0"
     df['HashApp'] = df.index
     df['HashFunction'] = df.index
     df["Trigger"] = "http"
 
     # Filter out functions with 0 invocations
+    prefiltered_df = df
+
     minute_bin_columns = df.columns[4:]
     df = df.dropna(subset=minute_bin_columns, how='all')
 
+    log.info(f"Inv df removed uninvoked functions (before -> after): {len(prefiltered_df)} -> {len(df)}")
+
     # Set 0 invocations from NaN to 0.
     df = df.fillna(0)
+    df = df.rename_axis(None, axis=1)
+    df = df.reset_index(drop=True)
+    df[minute_bin_columns] = df[minute_bin_columns].astype(np.int64)
 
     return df
 
@@ -116,6 +124,7 @@ def generate_mem_df(memory_limit_minute: pd.DataFrame) -> pd.DataFrame:
     # Make columns into minute bins
     df = memory_limit_minute.drop(columns='day')
     df['time'] = df['time']/60 + 1 # inv_df starts from minute 1
+    df['time'] = df['time'].astype(int).astype(str) # 1.0 -> 1
     df = df.set_index('time', drop=True)
     df = df.T
 
@@ -124,7 +133,7 @@ def generate_mem_df(memory_limit_minute: pd.DataFrame) -> pd.DataFrame:
 
     # Set IDs
     df["HashFunction"] = df.index
-    df["HashOwner"] = 0
+    df["HashOwner"] = "0"
     df['HashApp'] = df.index
 
     # Sample count is estimated as count of non-NAN samples
@@ -151,6 +160,8 @@ def generate_mem_df(memory_limit_minute: pd.DataFrame) -> pd.DataFrame:
         "AverageAllocatedMb_pct50", "AverageAllocatedMb_pct75", "AverageAllocatedMb_pct95", "AverageAllocatedMb_pct99", "AverageAllocatedMb_pct100"
     ]
     df = df.reindex(columns=column_order)
+    df = df.rename_axis(None, axis=1)
+    df = df.reset_index(drop=True)
 
     return df
 
@@ -159,7 +170,8 @@ def generate_dur_df(function_delay_minute: pd.DataFrame) -> pd.DataFrame:
 
     # Make columns into minute bins
     df = function_delay_minute.drop(columns='day')
-    df['time'] = df['time']/60 + 1 # inv_df starts fro#m minute 1
+    df['time'] = df['time']/60 + 1 # inv_df starts from minute 1
+    df['time'] = df['time'].astype(int).astype(str) # 1.0 -> 1
     df = df.set_index('time', drop=True)
     df = df.T
 
@@ -167,7 +179,7 @@ def generate_dur_df(function_delay_minute: pd.DataFrame) -> pd.DataFrame:
     min_bin_df = df[minute_bin_columns]
 
     # Set IDs
-    df["HashOwner"] = 0
+    df["HashOwner"] = "0"
     df['HashApp'] = df.index
     df["HashFunction"] = df.index
 
@@ -195,6 +207,8 @@ def generate_dur_df(function_delay_minute: pd.DataFrame) -> pd.DataFrame:
         "percentile_Average_75", "percentile_Average_99", "percentile_Average_100"
     ]
     df = df.reindex(columns=new_columns)
+    df = df.rename_axis(None, axis=1)
+    df = df.reset_index(drop=True)
 
     return df
 
@@ -215,9 +229,9 @@ def get_intersection(
     mem_df_cleaned = mem_df.set_index(cols).loc[common_idx].reset_index()
     run_df_cleaned = run_df.set_index(cols).loc[common_idx].reset_index()
 
-    log.debug(f"inv_df row count after intersection: {len(inv_df)}")
-    log.debug(f"mem_df row count after intersection: {len(mem_df)}")
-    log.debug(f"run_df row count after intersection: {len(run_df)}")
+    log.info(f"inv_df row count after intersection: {len(inv_df)}")
+    log.info(f"mem_df row count after intersection: {len(mem_df)}")
+    log.info(f"run_df row count after intersection: {len(run_df)}")
     
     return inv_df_cleaned, mem_df_cleaned, run_df_cleaned
 

--- a/sampler/sample.py
+++ b/sampler/sample.py
@@ -42,7 +42,7 @@ FIRST_MINUTES_COLUMN_POSITION = 4
 # Based on the following estimation:
 # Resources distribution is multiplicative of duration (in ms, avg 1000ms),
 # invocation count per minute (avg <10/min), and memory (in MB, avg 200MB)
-RES_NORM_FACTOR = 1000 * 10 * 100
+RES_NORM_FACTOR_AZURE2019 = 1000 * 10 * 100
 
 
 class Trace:
@@ -66,12 +66,17 @@ class Trace:
     # to find the best sample
     executor: concurrent.futures.ThreadPoolExecutor
 
+    # For non-azure2021 datasets
+    res_norm_factor: int
+
     def __init__(self,
                  name: str, inv_df: pd.DataFrame, mem_df: pd.DataFrame, run_df: pd.DataFrame,
                  # optional args below (used only for derived samples)
                  joined_df=pd.DataFrame(),
                  resources_df=pd.DataFrame(),
                  is_build_extra_dfs=False,
+                 # for non-azure2019 trace
+                 res_norm_factor=RES_NORM_FACTOR_AZURE2019,
                  ) -> None:
         log.debug(f"Initializing {name} trace...")
         self.name = name
@@ -85,6 +90,9 @@ class Trace:
         self.resources_df = resources_df
 
         self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=multiprocessing.cpu_count())
+
+        # Custom norm factor for non-azure2021 datasets
+        self.res_norm_factor = res_norm_factor
 
         if is_build_extra_dfs:
             # Only for the original trace: build the joined data frame with the resource usage specs
@@ -117,7 +125,7 @@ class Trace:
                 .multiply(self.joined_df['Run_x_Mem'], axis="index")
 
         # Divide by a normalization factor (to bring the resources series close to the invocation series)
-        self.resources_df.iloc[:, FIRST_MINUTES_COLUMN_POSITION:] /= RES_NORM_FACTOR
+        self.resources_df.iloc[:, FIRST_MINUTES_COLUMN_POSITION:] /= self.res_norm_factor
 
         log.debug(f"Resources df:\n{self.resources_df}")
 
@@ -376,11 +384,16 @@ def get_rolldown_samples(trace: Trace, original_trace: Trace, min_size: int, max
 
 def generate_samples(inv_df: pd.DataFrame, mem_df: pd.DataFrame, run_df: pd.DataFrame,
                      inv_df_orig: pd.DataFrame, mem_df_orig: pd.DataFrame, run_df_orig: pd.DataFrame,
-                     min_size: int, step: int, max_size: int, trial_num: int,
+                     min_size: int, step: int, max_size: int, trial_num: int, res_norm: int,
                      out_path: str
                      ):
-    original_trace = Trace(name="origin", inv_df=inv_df_orig, mem_df=mem_df_orig, run_df=run_df_orig, is_build_extra_dfs=True)
-    source_trace = Trace(name="source", inv_df=inv_df, mem_df=mem_df, run_df=run_df, is_build_extra_dfs=True)
+    if isinstance(res_norm, int):
+        res_norm_factor = res_norm
+    elif res_norm is None:
+        res_norm_factor = RES_NORM_FACTOR_AZURE2019
+
+    original_trace = Trace(name="origin", inv_df=inv_df_orig, mem_df=mem_df_orig, run_df=run_df_orig, is_build_extra_dfs=True, res_norm_factor=res_norm_factor)
+    source_trace = Trace(name="source", inv_df=inv_df, mem_df=mem_df, run_df=run_df, is_build_extra_dfs=True, res_norm_factor=res_norm_factor)
 
     log.info(f"The original trace has {source_trace.size} functions, "
              f"the best sample is selected based on {trial_num} attempts for each sample size")

--- a/sampler/tests/preprocessHuawei_test.py
+++ b/sampler/tests/preprocessHuawei_test.py
@@ -27,16 +27,115 @@ import pytest
 import os
 
 from sampler.preprocessHuawei import (
-    preprocess_huawei
+    preprocess_huawei,
+    generate_inv_df,
+    generate_mem_df,
+    generate_dur_df
 )
 
-def test_preprocess_huawei():
+# def test_preprocess_huawei():
 
-    os.getcwd() # Actual 
+#     os.getcwd() # Actual 
 
-    # Test preprocess_huawei
-    trace_dir = "yes"
-    start_time = "00:00:00"  # DD:HH:MM 
-    duration = 5             # Minutes
+#     # Test preprocess_huawei
+#     trace_dir = "yes"
+#     start_time = "00:00:00"  # DD:HH:MM 
+#     duration = 5             # Minutes
     
-    #preprocess_huawei(trace_dir: str, start_time: str, duration: str, output_dir: str)
+#     #preprocess_huawei(trace_dir: str, start_time: str, duration: str, output_dir: str)
+
+# MAYBE STILL IMPLEMENT
+# def test_time_slicing():
+#     return 0
+
+NaN = np.nan
+
+def test_generate_inv_df():
+    input_df = pd.DataFrame({
+        "day":  [0, 0, 0],
+        "time": [0, 60, 120],
+        "0":    [10, 20, 30],       #
+        "1":    [NaN, NaN, NaN],    # Zero invocations -> drop
+        "2":    [NaN, 10, NaN],     # At least 1 invocation -> keep
+        "3":    [5583, 3552, 4254], # 
+        "4":    [200, 0, 20],       # '0' in input -> keep
+    })
+
+    expected_df = pd.DataFrame({
+        "HashOwner":    ["0", "0", "0", "0"],
+        "HashApp":      ["0", "2", "3", "4"],
+        "HashFunction": ["0", "2", "3", "4"],
+        "Trigger":      ["http", "http", "http", "http"],
+        "1":            [10, 0, 5583, 200],
+        "2":            [20, 10, 3552, 0],
+        "3":            [30, 0, 4254, 20],
+    })
+
+    inv_df = generate_inv_df(input_df)
+    pd.testing.assert_frame_equal(inv_df, expected_df)
+
+def test_generate_mem_df():
+
+    input_df = pd.DataFrame({
+        "day":  [0, 0, 0],
+        "time": [0, 60, 120],
+        "0":    [400, 400, 400],    #
+        "1":    [NaN, NaN, NaN],    # Zero memory allocation -> drop
+        "2":    [NaN, 10, 20],      # At least 1 memory allocation -> keep
+        "3":    [10, 50, 90],       #
+    })
+
+    expected_df = pd.DataFrame({
+        "HashFunction":              ["0", "2", "3"],
+        "HashOwner":                 ["0", "0", "0"],
+        "HashApp":                   ["0", "2", "3"],
+        "SampleCount":               [  3,   2,   3],
+        "AverageAllocatedMb":        [400.0, 15.0, 50.0],
+        "AverageAllocatedMb_pct1":   [400.0, 10.1, 10.8],
+        "AverageAllocatedMb_pct5":   [400.0, 10.5, 14.0],
+        "AverageAllocatedMb_pct25":  [400.0, 12.5, 30.0],
+        "AverageAllocatedMb_pct50":  [400.0, 15.0, 50.0],
+        "AverageAllocatedMb_pct75":  [400.0, 17.5, 70.0],
+        "AverageAllocatedMb_pct95":  [400.0, 19.5, 86.0],
+        "AverageAllocatedMb_pct99":  [400.0, 19.9, 89.2],
+        "AverageAllocatedMb_pct100": [400.0, 20.0, 90.0],
+    })
+
+    mem_df = generate_mem_df(input_df)
+    pd.testing.assert_frame_equal(mem_df, expected_df)
+
+def test_generate_dur_df():
+
+    input_df = pd.DataFrame({
+        "day":  [0, 0, 0],
+        "time": [0, 60, 120],
+        "0":    [1.00, 1.50, 2.00],  # Standard
+        "1":    [NaN, NaN, NaN],     # Zero memory allocation -> drop
+        "2":    [NaN, 10.0, 10.0],   # At least 1 memory allocation
+        "3":    [1.0, 2.0, 3.555],   # Test 3dp precision
+    })
+
+    expected_df = pd.DataFrame({
+        "HashFunction":             [ "0",  "2",    "3"],
+        "HashOwner":                [ "0",  "0",    "0"],
+        "HashApp":                  [ "0",  "2",    "3"],
+        "Average":                  [ 1.5, 10.0,  2.185],
+        "Count":                    [   3,    2,      3],
+        "Minimum":                  [ 1.0, 10.0,    1.0],
+        "Maximum":                  [ 2.0, 10.0,  3.555],
+        "percentile_Average_0":     [1.00, 10.0,    1.0],
+        "percentile_Average_1":     [1.01, 10.0,   1.02],
+        "percentile_Average_25":    [1.25, 10.0,    1.5],
+        "percentile_Average_50":    [ 1.5, 10.0,      2],
+        "percentile_Average_75":    [1.75, 10.0, 2.7775],
+        "percentile_Average_99":    [1.99, 10.0, 3.5239],
+        "percentile_Average_100":   [2.00, 10.0,  3.555],
+    })
+
+    dur_df = generate_dur_df(input_df)
+    pd.testing.assert_frame_equal(dur_df, expected_df)
+
+
+# Full function happy path test
+def test_preprocess_huawei():
+    return 0

--- a/sampler/tests/preprocessHuawei_test.py
+++ b/sampler/tests/preprocessHuawei_test.py
@@ -1,0 +1,42 @@
+#  MIT License
+#
+#  Copyright (c) 2026 HySCALE and vHive community
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in all
+#  copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  SOFTWARE.
+
+from pathlib import Path
+
+import pandas as pd
+import numpy as np
+import pytest
+import os
+
+from sampler.preprocessHuawei import (
+    preprocess_huawei
+)
+
+def test_preprocess_huawei():
+
+    os.getcwd() # Actual 
+
+    # Test preprocess_huawei
+    trace_dir = "yes"
+    start_time = "00:00:00"  # DD:HH:MM 
+    duration = 5             # Minutes
+    
+    #preprocess_huawei(trace_dir: str, start_time: str, duration: str, output_dir: str)

--- a/sampler/tests/preprocessHuawei_test.py
+++ b/sampler/tests/preprocessHuawei_test.py
@@ -33,21 +33,6 @@ from sampler.preprocessHuawei import (
     generate_dur_df
 )
 
-# def test_preprocess_huawei():
-
-#     os.getcwd() # Actual 
-
-#     # Test preprocess_huawei
-#     trace_dir = "yes"
-#     start_time = "00:00:00"  # DD:HH:MM 
-#     duration = 5             # Minutes
-    
-#     #preprocess_huawei(trace_dir: str, start_time: str, duration: str, output_dir: str)
-
-# MAYBE STILL IMPLEMENT
-# def test_time_slicing():
-#     return 0
-
 NaN = np.nan
 
 def test_generate_inv_df():
@@ -134,8 +119,3 @@ def test_generate_dur_df():
 
     dur_df = generate_dur_df(input_df)
     pd.testing.assert_frame_equal(dur_df, expected_df)
-
-
-# Full function happy path test
-def test_preprocess_huawei():
-    return 0


### PR DESCRIPTION
## Summary

Transform `huawei2023-Private` trace dataset into `azure2019` format.
The Huawei trace can then be treated as an azure2019 trace for Sampler and Loader. 

## Implementation Notes :hammer_and_pick:

Only minute-binning has been implemented.
Updated `sampler` module to take custom resource normalization value in CLI when using `sample`, to account for differing value in different datasets.

## External Dependencies :four_leaf_clover:

None (N/A)

## Breaking API Changes :warning:

None (N/A)
