### PR TITLE
Support IBM2026 traces

### DIFF
--- a/.github/configs/wordlist.txt
+++ b/.github/configs/wordlist.txt
@@ -860,3 +860,6 @@ HuaWei
 huawei
 preprocessHuawei
 cmd
+convertIBM
+AsAzure
+ibm

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Standard sampled traces are available in [data/traces/reference](data/traces/ref
 - [Azure 2019](https://github.com/Azure/AzurePublicDataset/blob/master/AzureFunctionsDataset2019.md)
 - [Azure 2021](https://github.com/Azure/AzurePublicDataset/blob/master/AzureFunctionsInvocationTrace2021.md)
 - [Huawei 2023 Private](https://github.com/sir-lab/data-release/blob/main/README_data_release_2023.md)
+- [IBM 2026](https://github.com/ubc-cirrus-lab/ibm-cloud-code-engine-traces)
 
 ## Reference our work
 

--- a/docs/loader.md
+++ b/docs/loader.md
@@ -169,31 +169,30 @@ $ python -m sampler preprocessHuawei2023 -t data/huawei2023/private_dataset -o d
 $ go run cmd/loader.go --config cmd/config_knative_trace.json
 ```
 
-For more information about this conversion, the expected directory format of `private_dataset`, as well as instructions on sub-sampling the trace.
-Please refer to the [Huawei-2023 sampler documentation](sampler.md#using-huawei-2023-traces) in `sampler.md`.
+For more information about this conversion, the expected directory format of `private_dataset`, as well as instructions on sub-sampling the trace. Please refer to the [Huawei-2023 sampler documentation](sampler.md#using-huawei-2023-traces) in `sampler.md`.
 
 ### IBM2026
-To run `IBM2026` functions, the trace must be preprocessed and converted to an equivalent `Azure2021` trace.
-Assuming dataset is in `data/traces/ibm2026` and is formatted correctly, run the following:
+To run `IBM2026` functions, the trace must be preprocessed and converted to an equivalent `Azure2021` trace. Assuming dataset is in `data/traces/ibm2026` and is formatted correctly, run the following:
 
 ```bash
 # Extract excerpt (60 minutes starting from 1 hr) and convert 
 $ python -m sampler convertIBM2026 -t data/traces/ibm2026 -o data/traces/ibm2026/output -s 00:01:00 -dur 60
+```
+The trace is now in the `Azure2021` format, and can be optionally sub-sampled further, following the instructions in [Azure2021](sampler.md##using-azure2021-traces). Finally, run the following to load the trace:
 
+```bash
 # Run as Azure2021, Ensure to modify 'TracePath' in the .json to the resultant 'data/traces/ibm2026/output/IBM2026AsAzure2021.csv'
 $ go run cmd/loader.go --config cmd/config_knative2021_trace.json
 ```
 
-For information about this conversion and the expected directory format of `data/traces/ibm2026`.
-Please refer to the [IBM2026 sampler documentation](sampler.md#using-ibm-2026-traces) in `sampler.md`.
+For information about this conversion and the expected directory format of `data/traces/ibm2026`. Please refer to the [IBM2026 sampler documentation](sampler.md#using-ibm-2026-traces) in `sampler.md`.
 
 ### Additional settings
 Additionally, one can specify log verbosity argument as `--verbosity [info, debug, trace]`. The default value is `info`.
 
 To execute in a dry run mode without generating any load, set the `--dry-run` flag to `true`. This is useful for testing and validating configurations without executing actual requests.
 
-There are a couple of constants that should not be exposed to the users. They can be examined and changed
-in `pkg/common/constants.go`.
+There are a couple of constants that should not be exposed to the users. They can be examined and changed in `pkg/common/constants.go`.
 
 Sample sizes appropriate for performance evaluation vary depending on the platform. 
 As a starting point for fine-tuning, we suggest at most 5 functions per core with SMT disabled. 

--- a/docs/loader.md
+++ b/docs/loader.md
@@ -169,7 +169,7 @@ $ python -m sampler preprocessHuawei2023 -t data/huawei2023/private_dataset -o d
 $ go run cmd/loader.go --config cmd/config_knative_trace.json
 ```
 
-For more information about this conversion, the expected directory format of `private_dataset`, as well as instructions on sub-sampling the trace. Please refer to the [Huawei-2023 sampler documentation](sampler.md#using-huawei-2023-traces) in `sampler.md`.
+For more information about this conversion, the expected directory format of `private_dataset`, and instructions on sub-sampling the trace, please refer to the [Huawei-2023 sampler documentation](sampler.md#using-huawei-2023-traces) in `sampler.md`.
 
 ### IBM2026
 To run `IBM2026` functions, the trace must be preprocessed and converted to an equivalent `Azure2021` trace. Assuming dataset is in `data/traces/ibm2026` and is formatted correctly, run the following:
@@ -185,7 +185,7 @@ The trace is now in the `Azure2021` format, and can be optionally sub-sampled fu
 $ go run cmd/loader.go --config cmd/config_knative2021_trace.json
 ```
 
-For information about this conversion and the expected directory format of `data/traces/ibm2026`. Please refer to the [IBM2026 sampler documentation](sampler.md#using-ibm-2026-traces) in `sampler.md`.
+For information about this conversion and the expected directory format of `data/traces/ibm2026`, please refer to the [IBM2026 sampler documentation](sampler.md#using-ibm-2026-traces) in `sampler.md`.
 
 ### Additional settings
 Additionally, one can specify log verbosity argument as `--verbosity [info, debug, trace]`. The default value is `info`.

--- a/docs/loader.md
+++ b/docs/loader.md
@@ -11,6 +11,7 @@ can choose the APT cluster `d430` node.
 - Azure2019
 - Azure2021
 - Huawei-2023 Private
+- IBM2026
 
 ## Create a cluster
 
@@ -170,6 +171,21 @@ $ go run cmd/loader.go --config cmd/config_knative_trace.json
 
 For more information about this conversion, the expected directory format of `private_dataset`, as well as instructions on sub-sampling the trace.
 Please refer to the [Huawei-2023 sampler documentation](sampler.md#using-huawei-2023-traces) in `sampler.md`.
+
+### IBM2026
+To run `IBM2026` functions, the trace must be preprocessed and converted to an equivalent `Azure2021` trace.
+Assuming dataset is in `data/traces/ibm2026` and is formatted correctly, run the following:
+
+```bash
+# Extract excerpt (60 minutes starting from 1 hr) and convert 
+$ python -m sampler convertIBM2026 -t data/traces/ibm2026 -o data/traces/ibm2026/output -s 00:01:00 -dur 60
+
+# Run as Azure2021, Ensure to modify 'TracePath' in the .json to the resultant 'data/traces/ibm2026/output/IBM2026AsAzure2021.csv'
+$ go run cmd/loader.go --config cmd/config_knative2021_trace.json
+```
+
+For information about this conversion and the expected directory format of `data/traces/ibm2026`.
+Please refer to the [IBM2026 sampler documentation](sampler.md#using-ibm-2026-traces) in `sampler.md`.
 
 ### Additional settings
 Additionally, one can specify log verbosity argument as `--verbosity [info, debug, trace]`. The default value is `info`.

--- a/docs/sampler.md
+++ b/docs/sampler.md
@@ -255,8 +255,46 @@ A '-res' value of 1,000,000 was found empirically as mean of dataset of non-NAN 
 ```
 
 ### Preprocess Huawei-2023 
-
 The preprocessing follows 3 steps:
 1. Filter for invocations within user supplied time interval.
 2. Calculate percentile statistics for `run_df` and `mem_df` using non-zero data points within the time interval.
 3. Transform the trace to azure2019 format. 
+
+## Using IBM2026 Traces
+IBM2026 traces are supported by transforming it into Azure2021 format in `convertIBM2026`.
+It is then treated as an Azure2021 trace in InVitro for Sampler and Loader. 
+
+### Folder structure
+Download and extract (7zip) the original dataset from the [IBM2026 github repo](https://github.com/ubc-cirrus-lab/ibm-cloud-code-engine-traces). (default location: `invitro/data/traces/ibm2026/`).
+
+Ensure the extracted pickle files are contained within a directory.
+An example is shown below: 
+```bash
+invitro/data/traces/
+├── ibm2026
+    ├── app_configs.pickle
+    ├── week_1.pickle
+    ├── week_2.pickle
+    ├── ...
+    ├── week_9.pickle
+    └── week_10.pickle
+```
+
+### Workflow
+It should be noted that the `InvocationTimes` in IBM2026 appears to have a zero offset of 4 hours, 59 minutes, 59 seconds.
+For example, `week_1.pickle` contains timestamps from 0 days, 4:59:59 to 7 days 4:59:59.
+This offset is handled internally within `convertIBM2026`, timings for `-s` will start from 0 days, 4:59:59.
+
+The below conversion will:
+- Convert the trace to `azure2021` format.
+- Extract 60 minutes of invocations, from the timestamp interval from 5:59:59 to 6:59:59 (hour 1 to 2). 
+- The output timestamps in `end_timestamp` will be zero-ed, using the start of the timestamp interval as zero.
+
+Example conversion:
+```Bash
+$ python -m sampler convertIBM2026 -t data/traces/ibm2026 -o data/traces/ibm2026/output -s 00:01:00 -dur 60
+```
+
+The output trace can then either:
+- Be used directly in [Loader](loader.md#ibm2026)
+- Be sub-sampled further, following instructions in [Azure2021](#using-azure2021-traces)

--- a/sampler/__main__.py
+++ b/sampler/__main__.py
@@ -34,7 +34,7 @@ from sampler.sample import generate_samples
 from sampler.preprocess2021 import preprocess_file
 from sampler.preprocessHuawei import preprocess_huawei
 from sampler.filter import filter_azure2021
-from sampler.preprocessIBM2026 import preprocess_IBM2026
+from sampler.preprocessIBM2026 import preprocessIBM2026
 
 log.basicConfig(format='%(levelname)s:%(message)s', level=log.INFO)
 
@@ -84,8 +84,8 @@ def run(args):
                          start_time=args.start, duration=args.duration)
         return
 
-    if args.cmd == 'convertIBM2026':
-        preprocess_IBM2026(trace=args.trace, start=args.start, duration=args.duration, output=args.output)
+    if args.cmd == 'preprocessIBM2026':
+        preprocessIBM2026(trace_dir=args.trace, start_time=args.start, duration=args.duration, output_dir=args.output)
         return
 
     inv_df = pd.read_csv(f"{args.source_trace}/invocations.csv")
@@ -396,7 +396,7 @@ def main():
     ####################################################
     # IBM2026 Conversion to Azure2021
 
-    ibm2026_parser = subparser.add_parser('convertIBM2026')
+    ibm2026_parser = subparser.add_parser('preprocessIBM2026')
 
     ibm2026_parser.add_argument(
         '-t',

--- a/sampler/__main__.py
+++ b/sampler/__main__.py
@@ -34,7 +34,7 @@ from sampler.sample import generate_samples
 from sampler.preprocess2021 import preprocess_file
 from sampler.preprocessHuawei import preprocess_huawei
 from sampler.filter import filter_azure2021
-from sampler.preprocessIBM2026 import preprocessIBM2026
+from sampler.preprocessIBM2026 import preprocess_IBM2026
 
 log.basicConfig(format='%(levelname)s:%(message)s', level=log.INFO)
 
@@ -85,7 +85,7 @@ def run(args):
         return
 
     if args.cmd == 'convertIBM2026':
-        preprocessIBM2026(trace_dir=args.trace, start_time=args.start, duration=args.duration, output_dir=args.output)
+        preprocess_IBM2026(trace=args.trace, start=args.start, duration=args.duration, output=args.output)
         return
 
     inv_df = pd.read_csv(f"{args.source_trace}/invocations.csv")

--- a/sampler/__main__.py
+++ b/sampler/__main__.py
@@ -34,6 +34,7 @@ from sampler.sample import generate_samples
 from sampler.preprocess2021 import preprocess_file
 from sampler.preprocessHuawei import preprocess_huawei
 from sampler.filter import filter_azure2021
+from sampler.preprocessIBM2026 import preprocessIBM2026
 
 log.basicConfig(format='%(levelname)s:%(message)s', level=log.INFO)
 
@@ -81,6 +82,10 @@ def run(args):
     if args.cmd == 'filter2021':
         filter_azure2021(orig_trace_path=args.trace, sampled_trace_dir=args.sampled_trace, out_dir=args.output, 
                          start_time=args.start, duration=args.duration)
+        return
+
+    if args.cmd == 'convertIBM2026':
+        preprocessIBM2026(trace_dir=args.trace, start_time=args.start, duration=args.duration, output_dir=args.output)
         return
 
     inv_df = pd.read_csv(f"{args.source_trace}/invocations.csv")
@@ -386,6 +391,44 @@ def main():
         required=True,
         metavar='out_path',
         help='Directory path of the preprocessed traces'
+    )
+
+    ####################################################
+    # IBM2026 Conversion to Azure2021
+
+    ibm2026_parser = subparser.add_parser('convertIBM2026')
+
+    ibm2026_parser.add_argument(
+        '-t',
+        '--trace',
+        required=True,
+        metavar='path',
+        help='Directory path containing the ibm2026 pickle files. ' \
+        'This directory should contain app_config.pickle and the week_X.pickle (1 to 10) files'
+    )
+
+    ibm2026_parser.add_argument(
+        '-s',
+        '--start',
+        required=True,
+        metavar='start',
+        help='Time in dd:hh:mm format, at which the excerpt of the trace should begin, first day is day 0'
+    )
+
+    ibm2026_parser.add_argument(
+        '-dur',
+        '--duration',
+        required=True,
+        metavar='duration',
+        help='Duration in minutes to extract from the trace'
+    )
+
+    ibm2026_parser.add_argument(
+        '-o',
+        '--output',
+        required=True,
+        metavar='out_path',
+        help='Directory path to write the converted azure2021 trace'
     )
 
     ####################################################

--- a/sampler/preprocessIBM2026.py
+++ b/sampler/preprocessIBM2026.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from typing import Tuple
 from glob import glob
 
-def convert_ibm2026_to_azure2019(trace_dir: str, start_time: str, duration: str):
+def convert_ibm2026_to_azure2019(trace_dir: str, start_time: str, duration: str, output_dir: str):
 
     # Verify folder is correctly formatted
     ## Ensure folder exists
@@ -53,10 +53,9 @@ def convert_ibm2026_to_azure2019(trace_dir: str, start_time: str, duration: str)
 
     ## Dataset has timestamp zero offset at 4:59:59
     dataset_zero = pd.Timedelta(hours=4, minutes=59, seconds=59)
-    td_interval_start_with_zero = td_interval_start + dataset_zero
-    start_sec_zeroed = td_interval_start_with_zero.total_seconds()
-    td_interval_end_with_zero = td_interval_end + dataset_zero
-    end_sec_zeroed = td_interval_end_with_zero.total_seconds()
+    zero_offset_seconds = dataset_zero.total_seconds()
+    start_sec_zeroed = (td_interval_start + dataset_zero).total_seconds()
+    end_sec_zeroed = (td_interval_end + dataset_zero).total_seconds()
 
     final_df = pd.DataFrame()
 
@@ -87,7 +86,8 @@ def convert_ibm2026_to_azure2019(trace_dir: str, start_time: str, duration: str)
             mask = (inv_arr > start_sec_zeroed) & (inv_arr < end_sec_zeroed)
             
             num_events.append(mask.sum())
-            filtered_inv.append(inv_arr[mask].tolist())
+            # Keep only correctly zeroed timestamp
+            filtered_inv.append((inv_arr[mask] - zero_offset_seconds).tolist())
             filtered_app.append(np.array(app)[mask].tolist())
         df['NumEvents'] = num_events
         df['InvocationTimes'] = filtered_inv
@@ -121,72 +121,35 @@ def convert_ibm2026_to_azure2019(trace_dir: str, start_time: str, duration: str)
         final_df['AppExecTimes'] = sorted_app
 
     # Transform to azure2021 format
-    # (conversion) Then Transform explode into per-invocation basis/Azure2021 format.
+    final_df = final_df.drop(columns=['NumEvents'])
+    final_df = final_df.explode(['InvocationTimes', 'AppExecTimes'])
+    final_df['end_timestamp'] = (pd.to_timedelta(final_df["InvocationTimes"], unit="s") + pd.to_timedelta(final_df["AppExecTimes"], unit="ms"))
+    final_df['AppExecTimes'] = pd.to_timedelta(final_df["AppExecTimes"], unit="ms").dt.total_seconds()
 
+    # Start trace sample from 0
+    final_df['end_timestamp'] = (final_df['end_timestamp'] - td_interval_start).dt.total_seconds()
+
+    # Rename + Sort
+    final_df = final_df.rename(columns={'NamespaceHash': 'app', 'AppHash': 'func', 'AppExecTimes': 'duration'})
+    column_order = ["app", "func", "end_timestamp", "duration"]
+    final_df = final_df.reindex(columns=column_order)
+    final_df = final_df.sort_values(by='end_timestamp')
 
     # Save to output
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    final_df.to_csv(output_dir / "IBM2026AsAzure2021.csv", index=False)
 
-
-
-
-
-
-# def preprocess_huawei(trace_dir: str, start_time: str, duration: str, output_dir: str) -> pd.DataFrame:
-    
-#     # Read CSVs
-#     metrics_to_read = {
-#         "function_delay_minute": {"path": Path("function_delay_minute"), "df": pd.DataFrame()},
-#         "memory_limit_minute": {"path": Path("memory_limit_minute"), "df": pd.DataFrame()},
-#         "requests_minute": {"path": Path("function_delay_minute"), "df": pd.DataFrame()},
-#     }
-#     metrics = read_all_trace_csv(trace_dir, start_time, duration, metrics_to_read)
-
-#     # Transform to sampler format (inv_df, mem_df, run_df)
-
-#     # Save to output
-#     # output_dir = Path(output_dir)
-#     # output_dir.mkdir(parents=True, exist_ok=True)
-#     # inv_df.to_csv(output_dir / "invocations.csv", index=False)
-
-#     return
-
-# def read_all_trace_csv(trace_dir: str, start_time: str, duration: str, metrics: dict[str, dict[str, pd.DataFrame]]) -> dict[str, dict[str, pd.DataFrame]]:
-
-#     # Time interval filter
-#     start_time = start_time.split(":")
-#     day = int(start_time[0])
-#     hours = int(start_time[1])
-#     minutes = int(start_time[2])
-#     duration = int(duration)
-
-#     # Determine time interval
-#     td_interval_start = pd.Timedelta(days=day, hours=hours, minutes=minutes)
-#     td_interval_end = pd.Timedelta(days=day, hours=hours, minutes=(minutes+duration))
-#     starting_day = td_interval_start.days
-#     ending_day = td_interval_end.days
-
-#     # Read all metrics within time interval
-#     for metric, value in metrics.items():
-#         directory = Path(trace_dir) / value["path"]
-#         final_df = pd.DataFrame()
-
-#         # Determine files to read
-#         for day in range(starting_day, ending_day + 1):
-#             file_path = directory / f"day_{day:03d}.csv" # Leading zeros, width of 3 (001, 002)
-#             df = pd.read_csv(file_path)
-
-#             # Filter by timestamp
-#             df = df[df["time"].between(td_interval_start.total_seconds(), td_interval_end.total_seconds(), inclusive='left')] # left <= series < right
-
-#             final_df = pd.concat([final_df, df], ignore_index=True)
-
-#         value["df"] = final_df
-
-#     return metrics
+    # Save app_configs
+    file_path = Path(trace_dir / f"app_configs.pickle")
+    app_config_df = pd.read_pickle(file_path)
+    app_config_df.to_csv(output_dir / "app_configs.csv", index=False)
 
 if __name__ == "__main__":
     
     trace_dir: str = r"data\traces\pickle_data"
     start_time: str = r"00:01:00"
     duration_minutes: str = r"60"
-    convert_ibm2026_to_azure2019(trace_dir, start_time, duration_minutes)
+    output_dir: str = r"data\traces\output"
+
+    convert_ibm2026_to_azure2019(trace_dir, start_time, duration_minutes, output_dir)

--- a/sampler/preprocessIBM2026.py
+++ b/sampler/preprocessIBM2026.py
@@ -42,6 +42,8 @@ def preprocessIBM2026(trace_dir: str, start_time: str, duration: str, output_dir
         file = Path(trace_dir / file)
         assert file.exists(), f"Missing expected pickle file: {file.name}"
 
+    log.info('Found all expected pickle files.')
+
     # Determine time interval
     start_time = start_time.split(":")
     day = int(start_time[0])
@@ -56,6 +58,8 @@ def preprocessIBM2026(trace_dir: str, start_time: str, duration: str, output_dir
 
     ibm2026_df = read_df_from_pickle_files(trace_dir, td_interval_start, td_interval_end, dataset_zero)
 
+    log.info(f"Converting files to azure2021 format.")
+
     azure2021_df = convert_to_azure2021(ibm2026_df, td_interval_start)
 
     # Save azure2021_df
@@ -68,6 +72,7 @@ def preprocessIBM2026(trace_dir: str, start_time: str, duration: str, output_dir
     app_config_df = pd.read_pickle(file_path)
     app_config_df.to_csv(output_dir / "app_configs.csv", index=False)
 
+    log.info(f"Saved converted files to {output_dir}")
 
 # Reads df during time interval, normalises start time to 0, combines into per-function basis.
 # Concessions were made for speed reasons
@@ -84,7 +89,7 @@ def read_df_from_pickle_files(
     final_df = pd.DataFrame()
 
     for week in range(1, 11):
-    
+
         # Skip if time interval not within week.
         week_index = week - 1
         time_interval = pd.Interval(td_interval_start, td_interval_end)
@@ -93,6 +98,7 @@ def read_df_from_pickle_files(
             continue
 
         # Read DF
+        log.info(f"Reading week_{week}.pickle")
         file_path = Path(trace_dir / f"week_{week}.pickle")
         df = pd.read_pickle(file_path)
 
@@ -172,6 +178,8 @@ def convert_to_azure2021(ibm2026_df: pd.DataFrame, td_interval_start: pd.Timedel
 
 
 if __name__ == "__main__":
+
+    log.basicConfig(format='%(levelname)s:%(message)s', level=log.INFO)
     
     trace_dir: str = r"data\traces\pickle_data"
     start_time: str = r"00:01:00"
@@ -179,3 +187,5 @@ if __name__ == "__main__":
     output_dir: str = r"data\traces\output"
 
     preprocessIBM2026(trace_dir, start_time, duration_minutes, output_dir)
+
+    # `python -m sampler convertIBM2026 -t data/traces/pickle_data -o data/traces/output -s 00:01:00 -dur 60`

--- a/sampler/preprocessIBM2026.py
+++ b/sampler/preprocessIBM2026.py
@@ -28,27 +28,27 @@ from typing import Tuple
 from glob import glob
 
 # Parse files, convert to Azure2021, Save.
-def preprocessIBM2026(trace_dir: str, start_time: str, duration: str, output_dir: str):
+def preprocess_IBM2026(trace: str, start: str, duration: str, output: str):
 
     # Verify folder is correctly formatted
     ## Ensure folder exists
-    trace_dir = Path(trace_dir)
-    assert trace_dir.exists(), "Trace directory does not exist"
+    trace = Path(trace)
+    assert trace.exists(), "Trace directory does not exist"
 
     ## Ensure all 11 pickle files present (app_config + week 1-10)
     expected_files = ["app_configs.pickle"] + [f"week_{i}.pickle" for i in range(1, 11)]
 
     for file in expected_files:
-        file = Path(trace_dir / file)
+        file = Path(trace / file)
         assert file.exists(), f"Missing expected pickle file: {file.name}"
 
     log.info('Found all expected pickle files.')
 
     # Determine time interval
-    start_time = start_time.split(":")
-    day = int(start_time[0])
-    hours = int(start_time[1])
-    minutes = int(start_time[2])
+    start = start.split(":")
+    day = int(start[0])
+    hours = int(start[1])
+    minutes = int(start[2])
     duration = int(duration)
 
     ## Dataset has timestamp zero offset at 4:59:59
@@ -56,23 +56,23 @@ def preprocessIBM2026(trace_dir: str, start_time: str, duration: str, output_dir
     td_interval_start = pd.Timedelta(days=day, hours=hours, minutes=minutes)
     td_interval_end = pd.Timedelta(days=day, hours=hours, minutes=(minutes+duration))
 
-    ibm2026_df = read_df_from_pickle_files(trace_dir, td_interval_start, td_interval_end, dataset_zero)
+    ibm2026_df = read_df_from_pickle_files(trace, td_interval_start, td_interval_end, dataset_zero)
 
     log.info(f"Converting files to azure2021 format.")
 
     azure2021_df = convert_to_azure2021(ibm2026_df, td_interval_start)
 
     # Save azure2021_df
-    output_dir = Path(output_dir)
-    output_dir.mkdir(parents=True, exist_ok=True)
-    azure2021_df.to_csv(output_dir / "IBM2026AsAzure2021.csv", index=False)
+    output = Path(output)
+    output.mkdir(parents=True, exist_ok=True)
+    azure2021_df.to_csv(output / "IBM2026AsAzure2021.csv", index=False)
 
     # Save app_configs
-    file_path = Path(trace_dir / f"app_configs.pickle")
+    file_path = Path(trace / f"app_configs.pickle")
     app_config_df = pd.read_pickle(file_path)
-    app_config_df.to_csv(output_dir / "app_configs.csv", index=False)
+    app_config_df.to_csv(output / "app_configs.csv", index=False)
 
-    log.info(f"Saved converted files to {output_dir}")
+    log.info(f"Saved converted files to {output}")
 
 # Reads df during time interval, normalises start time to 0, combines into per-function basis.
 # Concessions were made for speed reasons

--- a/sampler/preprocessIBM2026.py
+++ b/sampler/preprocessIBM2026.py
@@ -1,0 +1,192 @@
+#  MIT License
+#
+#  Copyright (c) 2026 HySCALE and vHive community
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in all
+#  copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#  SOFTWARE.
+
+import pandas as pd
+import logging as log
+import numpy as np
+from pathlib import Path
+from typing import Tuple
+from glob import glob
+
+def convert_ibm2026_to_azure2019(trace_dir: str, start_time: str, duration: str):
+
+    # Verify folder is correctly formatted
+    ## Ensure folder exists
+    trace_dir = Path(trace_dir)
+    assert trace_dir.exists(), "Trace directory does not exist"
+
+    ## Ensure all 11 pickle files present (app_config + week 1-10)
+    expected_files = ["app_configs.pickle"] + [f"week_{i}.pickle" for i in range(1, 11)]
+
+    for file in expected_files:
+        file = Path(trace_dir / file)
+        assert file.exists(), f"Missing expected pickle file: {file.name}"
+
+    # Determine time interval
+    start_time = start_time.split(":")
+    day = int(start_time[0])
+    hours = int(start_time[1])
+    minutes = int(start_time[2])
+    duration = int(duration)
+
+    td_interval_start = pd.Timedelta(days=day, hours=hours, minutes=minutes)
+    td_interval_end = pd.Timedelta(days=day, hours=hours, minutes=(minutes+duration))
+
+    ## Dataset has timestamp zero offset at 4:59:59
+    dataset_zero = pd.Timedelta(hours=4, minutes=59, seconds=59)
+    td_interval_start_with_zero = td_interval_start + dataset_zero
+    start_sec_zeroed = td_interval_start_with_zero.total_seconds()
+    td_interval_end_with_zero = td_interval_end + dataset_zero
+    end_sec_zeroed = td_interval_end_with_zero.total_seconds()
+
+    final_df = pd.DataFrame()
+
+    # Read Weekly Data Files
+    for week in range(1, 11):
+
+        # Skip if time interval not within week.
+        week_index = week - 1
+        time_interval = pd.Interval(td_interval_start, td_interval_end)
+        file_time_interval = pd.Interval(left=pd.Timedelta(days=(week_index)*7), right=pd.Timedelta(days=(week_index+1)*7), closed='left')
+        if (time_interval not in file_time_interval):
+            continue
+
+        # Read DF
+        file_path = Path(trace_dir / f"week_{week}.pickle")
+        df = pd.read_pickle(file_path)
+
+        # Pre-clean unused columns
+        df = df.drop(columns=['TotalExecTimes', 'PodHash']) 
+
+        # Filter invocations within interval
+        num_events = []
+        filtered_inv, filtered_app = [], []
+        for inv, app in zip(df['InvocationTimes'], df['AppExecTimes']):
+            inv_arr = np.array(inv)
+
+            # Vectorized NumPy mask
+            mask = (inv_arr > start_sec_zeroed) & (inv_arr < end_sec_zeroed)
+            
+            num_events.append(mask.sum())
+            filtered_inv.append(inv_arr[mask].tolist())
+            filtered_app.append(np.array(app)[mask].tolist())
+        df['NumEvents'] = num_events
+        df['InvocationTimes'] = filtered_inv
+        df['AppExecTimes'] = filtered_app
+
+        # cleanup
+        df = df[df['InvocationTimes'].str.len() > 0]
+
+        # Combine Dataframes (Interval across multiple weeks)
+        final_df = pd.concat([final_df, df], axis=0, ignore_index=True)
+
+        ## Combine same applications
+        final_df = final_df.groupby(['NamespaceHash', 'AppHash'], as_index=False).agg({
+            'NumEvents': 'sum',        # mathematical sum
+            'InvocationTimes': 'sum',  # concat lists
+            'AppExecTimes': 'sum',     # concat lists
+        })
+
+        ## Sort InvocationTimes, ensuring AppExecTimes follow order
+        sorted_inv = []
+        sorted_app = []
+        for inv, app in zip(final_df['InvocationTimes'], final_df['AppExecTimes']):
+            inv_arr = np.array(inv)
+            app_arr = np.array(app)
+
+            sort_idx = np.argsort(inv_arr)
+
+            sorted_inv.append(inv_arr[sort_idx].tolist())
+            sorted_app.append(app_arr[sort_idx].tolist())
+        final_df['InvocationTimes'] = sorted_inv
+        final_df['AppExecTimes'] = sorted_app
+
+    # Transform to azure2021 format
+    # (conversion) Then Transform explode into per-invocation basis/Azure2021 format.
+
+
+    # Save to output
+
+
+
+
+
+
+# def preprocess_huawei(trace_dir: str, start_time: str, duration: str, output_dir: str) -> pd.DataFrame:
+    
+#     # Read CSVs
+#     metrics_to_read = {
+#         "function_delay_minute": {"path": Path("function_delay_minute"), "df": pd.DataFrame()},
+#         "memory_limit_minute": {"path": Path("memory_limit_minute"), "df": pd.DataFrame()},
+#         "requests_minute": {"path": Path("function_delay_minute"), "df": pd.DataFrame()},
+#     }
+#     metrics = read_all_trace_csv(trace_dir, start_time, duration, metrics_to_read)
+
+#     # Transform to sampler format (inv_df, mem_df, run_df)
+
+#     # Save to output
+#     # output_dir = Path(output_dir)
+#     # output_dir.mkdir(parents=True, exist_ok=True)
+#     # inv_df.to_csv(output_dir / "invocations.csv", index=False)
+
+#     return
+
+# def read_all_trace_csv(trace_dir: str, start_time: str, duration: str, metrics: dict[str, dict[str, pd.DataFrame]]) -> dict[str, dict[str, pd.DataFrame]]:
+
+#     # Time interval filter
+#     start_time = start_time.split(":")
+#     day = int(start_time[0])
+#     hours = int(start_time[1])
+#     minutes = int(start_time[2])
+#     duration = int(duration)
+
+#     # Determine time interval
+#     td_interval_start = pd.Timedelta(days=day, hours=hours, minutes=minutes)
+#     td_interval_end = pd.Timedelta(days=day, hours=hours, minutes=(minutes+duration))
+#     starting_day = td_interval_start.days
+#     ending_day = td_interval_end.days
+
+#     # Read all metrics within time interval
+#     for metric, value in metrics.items():
+#         directory = Path(trace_dir) / value["path"]
+#         final_df = pd.DataFrame()
+
+#         # Determine files to read
+#         for day in range(starting_day, ending_day + 1):
+#             file_path = directory / f"day_{day:03d}.csv" # Leading zeros, width of 3 (001, 002)
+#             df = pd.read_csv(file_path)
+
+#             # Filter by timestamp
+#             df = df[df["time"].between(td_interval_start.total_seconds(), td_interval_end.total_seconds(), inclusive='left')] # left <= series < right
+
+#             final_df = pd.concat([final_df, df], ignore_index=True)
+
+#         value["df"] = final_df
+
+#     return metrics
+
+if __name__ == "__main__":
+    
+    trace_dir: str = r"data\traces\pickle_data"
+    start_time: str = r"00:01:00"
+    duration_minutes: str = r"60"
+    convert_ibm2026_to_azure2019(trace_dir, start_time, duration_minutes)

--- a/sampler/preprocessIBM2026.py
+++ b/sampler/preprocessIBM2026.py
@@ -89,7 +89,7 @@ def read_df_from_pickle_files(
         week_index = week - 1
         time_interval = pd.Interval(td_interval_start, td_interval_end)
         file_time_interval = pd.Interval(left=pd.Timedelta(days=(week_index)*7), right=pd.Timedelta(days=(week_index+1)*7), closed='left')
-        if (time_interval not in file_time_interval):
+        if not (file_time_interval.overlaps(time_interval)):
             continue
 
         # Read DF

--- a/sampler/preprocessIBM2026.py
+++ b/sampler/preprocessIBM2026.py
@@ -28,27 +28,27 @@ from typing import Tuple
 from glob import glob
 
 # Parse files, convert to Azure2021, Save.
-def preprocess_IBM2026(trace: str, start: str, duration: str, output: str):
+def preprocessIBM2026(trace_dir: str, start_time: str, duration: str, output_dir: str):
 
     # Verify folder is correctly formatted
     ## Ensure folder exists
-    trace = Path(trace)
-    assert trace.exists(), "Trace directory does not exist"
+    trace_dir = Path(trace_dir)
+    assert trace_dir.exists(), "Trace directory does not exist"
 
     ## Ensure all 11 pickle files present (app_config + week 1-10)
     expected_files = ["app_configs.pickle"] + [f"week_{i}.pickle" for i in range(1, 11)]
 
     for file in expected_files:
-        file = Path(trace / file)
+        file = Path(trace_dir / file)
         assert file.exists(), f"Missing expected pickle file: {file.name}"
 
     log.info('Found all expected pickle files.')
 
     # Determine time interval
-    start = start.split(":")
-    day = int(start[0])
-    hours = int(start[1])
-    minutes = int(start[2])
+    start_time = start_time.split(":")
+    day = int(start_time[0])
+    hours = int(start_time[1])
+    minutes = int(start_time[2])
     duration = int(duration)
 
     ## Dataset has timestamp zero offset at 4:59:59
@@ -56,23 +56,23 @@ def preprocess_IBM2026(trace: str, start: str, duration: str, output: str):
     td_interval_start = pd.Timedelta(days=day, hours=hours, minutes=minutes)
     td_interval_end = pd.Timedelta(days=day, hours=hours, minutes=(minutes+duration))
 
-    ibm2026_df = read_df_from_pickle_files(trace, td_interval_start, td_interval_end, dataset_zero)
+    ibm2026_df = read_df_from_pickle_files(trace_dir, td_interval_start, td_interval_end, dataset_zero)
 
     log.info(f"Converting files to azure2021 format.")
 
     azure2021_df = convert_to_azure2021(ibm2026_df, td_interval_start)
 
     # Save azure2021_df
-    output = Path(output)
-    output.mkdir(parents=True, exist_ok=True)
-    azure2021_df.to_csv(output / "IBM2026AsAzure2021.csv", index=False)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    azure2021_df.to_csv(output_dir / "IBM2026AsAzure2021.csv", index=False)
 
     # Save app_configs
-    file_path = Path(trace / f"app_configs.pickle")
+    file_path = Path(trace_dir / f"app_configs.pickle")
     app_config_df = pd.read_pickle(file_path)
-    app_config_df.to_csv(output / "app_configs.csv", index=False)
+    app_config_df.to_csv(output_dir / "app_configs.csv", index=False)
 
-    log.info(f"Saved converted files to {output}")
+    log.info(f"Saved converted files to {output_dir}")
 
 # Reads df during time interval, normalises start time to 0, combines into per-function basis.
 # Concessions were made for speed reasons

--- a/sampler/preprocessIBM2026.py
+++ b/sampler/preprocessIBM2026.py
@@ -176,16 +176,3 @@ def convert_to_azure2021(ibm2026_df: pd.DataFrame, td_interval_start: pd.Timedel
 
     return df
 
-
-if __name__ == "__main__":
-
-    log.basicConfig(format='%(levelname)s:%(message)s', level=log.INFO)
-    
-    trace_dir: str = r"data\traces\pickle_data"
-    start_time: str = r"00:01:00"
-    duration_minutes: str = r"60"
-    output_dir: str = r"data\traces\output"
-
-    preprocessIBM2026(trace_dir, start_time, duration_minutes, output_dir)
-
-    # `python -m sampler convertIBM2026 -t data/traces/pickle_data -o data/traces/output -s 00:01:00 -dur 60`

--- a/sampler/preprocessIBM2026.py
+++ b/sampler/preprocessIBM2026.py
@@ -27,7 +27,8 @@ from pathlib import Path
 from typing import Tuple
 from glob import glob
 
-def convert_ibm2026_to_azure2019(trace_dir: str, start_time: str, duration: str, output_dir: str):
+# Parse files, convert to Azure2021, Save.
+def preprocessIBM2026(trace_dir: str, start_time: str, duration: str, output_dir: str):
 
     # Verify folder is correctly formatted
     ## Ensure folder exists
@@ -48,20 +49,42 @@ def convert_ibm2026_to_azure2019(trace_dir: str, start_time: str, duration: str,
     minutes = int(start_time[2])
     duration = int(duration)
 
+    ## Dataset has timestamp zero offset at 4:59:59
+    dataset_zero = pd.Timedelta(hours=4, minutes=59, seconds=59)
     td_interval_start = pd.Timedelta(days=day, hours=hours, minutes=minutes)
     td_interval_end = pd.Timedelta(days=day, hours=hours, minutes=(minutes+duration))
 
-    ## Dataset has timestamp zero offset at 4:59:59
-    dataset_zero = pd.Timedelta(hours=4, minutes=59, seconds=59)
+    ibm2026_df = read_df_from_pickle_files(trace_dir, td_interval_start, td_interval_end, dataset_zero)
+
+    azure2021_df = convert_to_azure2021(ibm2026_df, td_interval_start)
+
+    # Save azure2021_df
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    azure2021_df.to_csv(output_dir / "IBM2026AsAzure2021.csv", index=False)
+
+    # Save app_configs
+    file_path = Path(trace_dir / f"app_configs.pickle")
+    app_config_df = pd.read_pickle(file_path)
+    app_config_df.to_csv(output_dir / "app_configs.csv", index=False)
+
+
+# Reads df during time interval, normalises start time to 0, combines into per-function basis.
+# Concessions were made for speed reasons
+def read_df_from_pickle_files(
+        trace_dir: Path, td_interval_start: pd.Timedelta, 
+        td_interval_end: pd.Timedelta, dataset_zero: pd.Timedelta, 
+        ) -> pd.DataFrame:
+
+    # Precalculate floats
     zero_offset_seconds = dataset_zero.total_seconds()
     start_sec_zeroed = (td_interval_start + dataset_zero).total_seconds()
     end_sec_zeroed = (td_interval_end + dataset_zero).total_seconds()
 
     final_df = pd.DataFrame()
 
-    # Read Weekly Data Files
     for week in range(1, 11):
-
+    
         # Skip if time interval not within week.
         week_index = week - 1
         time_interval = pd.Interval(td_interval_start, td_interval_end)
@@ -86,8 +109,12 @@ def convert_ibm2026_to_azure2019(trace_dir: str, start_time: str, duration: str,
             mask = (inv_arr > start_sec_zeroed) & (inv_arr < end_sec_zeroed)
             
             num_events.append(mask.sum())
+
             # Keep only correctly zeroed timestamp
-            filtered_inv.append((inv_arr[mask] - zero_offset_seconds).tolist())
+            arr_td = pd.to_timedelta(inv_arr[mask], unit='s')
+            fixed_td = pd.Timedelta(seconds=zero_offset_seconds)
+
+            filtered_inv.append((arr_td - fixed_td).total_seconds().tolist())
             filtered_app.append(np.array(app)[mask].tolist())
         df['NumEvents'] = num_events
         df['InvocationTimes'] = filtered_inv
@@ -106,44 +133,43 @@ def convert_ibm2026_to_azure2019(trace_dir: str, start_time: str, duration: str,
             'AppExecTimes': 'sum',     # concat lists
         })
 
-        ## Sort InvocationTimes, ensuring AppExecTimes follow order
-        sorted_inv = []
-        sorted_app = []
-        for inv, app in zip(final_df['InvocationTimes'], final_df['AppExecTimes']):
-            inv_arr = np.array(inv)
-            app_arr = np.array(app)
+    ## Sort InvocationTimes, ensuring AppExecTimes follow order
+    sorted_inv = []
+    sorted_app = []
+    for inv, app in zip(final_df['InvocationTimes'], final_df['AppExecTimes']):
+        inv_arr = np.array(inv)
+        app_arr = np.array(app)
 
-            sort_idx = np.argsort(inv_arr)
+        sort_idx = np.argsort(inv_arr)
 
-            sorted_inv.append(inv_arr[sort_idx].tolist())
-            sorted_app.append(app_arr[sort_idx].tolist())
-        final_df['InvocationTimes'] = sorted_inv
-        final_df['AppExecTimes'] = sorted_app
+        sorted_inv.append(inv_arr[sort_idx].tolist())
+        sorted_app.append(app_arr[sort_idx].tolist())
+    final_df['InvocationTimes'] = sorted_inv
+    final_df['AppExecTimes'] = sorted_app
+
+    return final_df
+
+
+def convert_to_azure2021(ibm2026_df: pd.DataFrame, td_interval_start: pd.Timedelta) -> pd.DataFrame:
 
     # Transform to azure2021 format
-    final_df = final_df.drop(columns=['NumEvents'])
-    final_df = final_df.explode(['InvocationTimes', 'AppExecTimes'])
-    final_df['end_timestamp'] = (pd.to_timedelta(final_df["InvocationTimes"], unit="s") + pd.to_timedelta(final_df["AppExecTimes"], unit="ms"))
-    final_df['AppExecTimes'] = pd.to_timedelta(final_df["AppExecTimes"], unit="ms").dt.total_seconds()
+    df = ibm2026_df.drop(columns=['NumEvents'])
+    df = df.explode(['InvocationTimes', 'AppExecTimes'])
+    df['end_timestamp'] = (pd.to_timedelta(df["InvocationTimes"], unit="s") + pd.to_timedelta(df["AppExecTimes"], unit="ms"))
+    df['AppExecTimes'] = pd.to_timedelta(df["AppExecTimes"], unit="ms").dt.total_seconds()
 
     # Start trace sample from 0
-    final_df['end_timestamp'] = (final_df['end_timestamp'] - td_interval_start).dt.total_seconds()
+    df['end_timestamp'] = (df['end_timestamp'] - td_interval_start).dt.total_seconds()
 
     # Rename + Sort
-    final_df = final_df.rename(columns={'NamespaceHash': 'app', 'AppHash': 'func', 'AppExecTimes': 'duration'})
+    df = df.rename(columns={'NamespaceHash': 'app', 'AppHash': 'func', 'AppExecTimes': 'duration'})
     column_order = ["app", "func", "end_timestamp", "duration"]
-    final_df = final_df.reindex(columns=column_order)
-    final_df = final_df.sort_values(by='end_timestamp')
+    df = df.reindex(columns=column_order)
+    df = df.sort_values(by='end_timestamp')
+    df = df.reset_index(drop=True)
 
-    # Save to output
-    output_dir = Path(output_dir)
-    output_dir.mkdir(parents=True, exist_ok=True)
-    final_df.to_csv(output_dir / "IBM2026AsAzure2021.csv", index=False)
+    return df
 
-    # Save app_configs
-    file_path = Path(trace_dir / f"app_configs.pickle")
-    app_config_df = pd.read_pickle(file_path)
-    app_config_df.to_csv(output_dir / "app_configs.csv", index=False)
 
 if __name__ == "__main__":
     
@@ -152,4 +178,4 @@ if __name__ == "__main__":
     duration_minutes: str = r"60"
     output_dir: str = r"data\traces\output"
 
-    convert_ibm2026_to_azure2019(trace_dir, start_time, duration_minutes, output_dir)
+    preprocessIBM2026(trace_dir, start_time, duration_minutes, output_dir)

--- a/sampler/tests/preprocessIBM2026_test.py
+++ b/sampler/tests/preprocessIBM2026_test.py
@@ -1,0 +1,148 @@
+#  MIT License
+#
+#  Copyright (c) 2026 HySCALE and vHive community
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in all
+#  copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  SOFTWARE.
+
+from pathlib import Path
+import pandas as pd
+import numpy as np
+
+from sampler.preprocessIBM2026 import (
+    convert_to_azure2021,
+    read_df_from_pickle_files
+)
+
+# What should unit tests test for? ->
+# 
+# Test reading from all pickles, obtaining a value.
+# Test conversion from IBM2026 ideal to azure 2019.
+
+def test_convert_to_azure2021():
+
+    input_df = pd.DataFrame({
+        "NamespaceHash":    ["0", "0", "1", "2"], # Test unique ID (namespace + app)
+        "AppHash":          ["A", "B", "B", "C"], # Test unique ID (namespace + app)
+        "NumEvents":        [1, 1, 2, 1],         # Test multiple events
+        "InvocationTimes":  [[10], [20.5], [33, 47], [33]], # Test end_timestamp sorting
+        "AppExecTimes":     [[3], [5], [10, 4], [5]] # ms
+    })
+
+    expected_df = pd.DataFrame({
+        "app":           ["0", "0", "2", "1", "1"],
+        "func":          ["A", "B", "C", "B", "B"],
+        "end_timestamp": [10.003, 20.505, 33.005, 33.01, 47.004],
+        "duration":      [0.003, 0.005, 0.005, 0.01, 0.004] # s
+    })
+
+    zero_td = pd.Timedelta(0, unit="s")
+    azure2021_df = convert_to_azure2021(input_df, zero_td)
+    pd.testing.assert_frame_equal(azure2021_df, expected_df)
+
+
+## Assume dataset has uniform offset start at 1 hour
+## Get invocations within 1 minute starting from 1 hr (Inovcations from 3600 -> 3660)
+def test_read_df_from_single_pickle_file(tmp_path):
+
+    trace_dir = tmp_path / "pickle_data"
+    trace_dir.mkdir()
+
+    # Week within interval
+    input_df = pd.DataFrame({
+        "NamespaceHash":    ["0", "0", "1", "2"], 
+        "AppHash":          ["A", "B", "B", "C"], 
+        "NumEvents":        [1, 1, 2, 1],         
+        "InvocationTimes":  [[3500], [3620.5], [3633, 3647], [5000]], # s # Test invocation interval filter
+        "AppExecTimes":     [[3], [5], [10, 4], [5]], # ms
+        "TotalExecTimes":   [[10], [10], [15, 10], [10]], # ms
+        "PodHash":          [['AAA'], ['BBB'], ['CCC', 'CCC'], ['DDD']]
+    })
+    input_df.to_pickle(trace_dir / "week_1.pickle")
+
+    # Expected
+    expected_df = pd.DataFrame({
+        "NamespaceHash":    ["0", "1"], 
+        "AppHash":          ["B", "B"], 
+        "NumEvents":        [1, 2],         
+        "InvocationTimes":  [[20.5], [33, 47]], 
+        "AppExecTimes":     [[5], [10, 4]]
+    })
+
+    # Invocation Parameters
+    day = 0
+    hours = 0
+    minutes = 0
+    duration_minutes = 1
+    dataset_zero = pd.Timedelta(hours=1, minutes=0, seconds=0)
+    td_interval_start = pd.Timedelta(days=day, hours=hours, minutes=minutes)
+    td_interval_end = pd.Timedelta(days=day, hours=hours, minutes=(minutes+duration_minutes))
+
+    ibm2026_df = read_df_from_pickle_files(trace_dir, td_interval_start, td_interval_end, dataset_zero)
+
+    pd.testing.assert_frame_equal(ibm2026_df, expected_df)
+
+# interval span both week 1 and 2
+# seconds interval (603,000 -> 606,600)
+def test_read_df_from_multiple_pickle_files(tmp_path):
+    trace_dir = tmp_path / "pickle_data"
+    trace_dir.mkdir()
+
+    # Input
+    week1_df = pd.DataFrame({
+        "NamespaceHash":    ["0", "1"], 
+        "AppHash":          ["A", "B"], 
+        "NumEvents":        [1, 1],         
+        "InvocationTimes":  [[602_000], [603_010]],
+        "AppExecTimes":     [[10], [20]], 
+        "TotalExecTimes":   [[100], [100]],
+        "PodHash":          [['AAA'], ['AAA']]
+    })
+    week1_df.to_pickle(trace_dir / "week_1.pickle")
+
+    week2_df = pd.DataFrame({
+        "NamespaceHash":    ["2", "3"], 
+        "AppHash":          ["B", "C"], 
+        "NumEvents":        [1, 1],         
+        "InvocationTimes":  [[606_500], [606_700]],
+        "AppExecTimes":     [[3], [5]],
+        "TotalExecTimes":   [[100], [100]],
+        "PodHash":          [['AAA'], ['AAA']]
+    })
+    week2_df.to_pickle(trace_dir / "week_2.pickle")
+
+    # Expected
+    expected_df = pd.DataFrame({
+        "NamespaceHash":    ["1", "2"], 
+        "AppHash":          ["B", "B"], 
+        "NumEvents":        [1, 1],         
+        "InvocationTimes":  [[603_010], [606_500]], 
+        "AppExecTimes":     [[20], [3]]
+    })
+
+    # Invocation Parameters
+    day = 6
+    hours = 23
+    minutes = 30
+    duration_minutes = 60
+    dataset_zero = pd.Timedelta(hours=0, minutes=0, seconds=0)
+    td_interval_start = pd.Timedelta(days=day, hours=hours, minutes=minutes)
+    td_interval_end = pd.Timedelta(days=day, hours=hours, minutes=(minutes+duration_minutes))
+
+    ibm2026_df = read_df_from_pickle_files(trace_dir, td_interval_start, td_interval_end, dataset_zero)
+
+    pd.testing.assert_frame_equal(ibm2026_df, expected_df)


### PR DESCRIPTION
## Summary

Supports IBM2026 traces for Loader and Sampler.
Implemented by converting `IBM2026` traces into `Azure2021` trace format, leverage existing pipeline for subsampling/loading `Azure2021` traces.

## Implementation Notes :hammer_and_pick:

* Most work is on handling the parsing of the pickle files.
* The `IBM2026` dataset has a zero offset for timestamps starting from 4:59:59 (`week_1.pickle` contains timestamps from 0 days, 4:59:59 to 7 days 4:59:59.). Converter will handle this and zero the timestamps (subtract 4:59:59).
* After conversion, `end_timestamps` will use the start of the user selected interval (`-s XX:XX:XX`) as zero.

## External Dependencies :four_leaf_clover:

none (N/A) 

## Breaking API Changes :warning:

none (N/A) 
