### PR TITLE
Add zero-ing of invocations for Azure2021 Loader

### DIFF
--- a/pkg/trace/azure2021_trace_parser.go
+++ b/pkg/trace/azure2021_trace_parser.go
@@ -63,9 +63,12 @@ const referenceMemoryValue int = common.Azure2021MemoryReferenceValue
 func (p *Azure2021TraceParser) Parse() []*common.Function {
 
 	invocationTracker := ParseCSVFile(p.FilePath)
-	var functions []*common.Function
+
+	/* Zero inovcations -> earliest invocation timestamp will fire immediately */
+	invocationTracker = ZeroInvocations(invocationTracker)
 
 	/* invocationTracker populated, begin creating function array. */
+	var functions []*common.Function
 	for funcID, invocationSlice := range invocationTracker {
 		funcSpec, empty := GenerateFunctionSpecification(invocationSlice, p.durationMinutes)
 		if empty {
@@ -162,6 +165,33 @@ func ParseCSVFile(filePath string) map[UniqueFunctionID]Invocations {
 	return invocationTracker
 }
 
+func ZeroInvocations(invocationTracker map[UniqueFunctionID]Invocations) map[UniqueFunctionID]Invocations {
+
+	if len(invocationTracker) == 0 {
+		return invocationTracker
+	}
+
+	minTime := math.MaxFloat64
+
+	// Pass 1: Find the absolute smallest startTime across all function IDs
+	for _, invocationArray := range invocationTracker {
+		for _, invocation := range invocationArray {
+			if invocation.startTime < minTime {
+				minTime = invocation.startTime
+			}
+		}
+	}
+
+	// Pass 2: Subtract the smallest timestamp from every invocation
+	for _, invocationArray := range invocationTracker {
+		for i := range invocationArray {
+			invocationArray[i].startTime -= minTime
+		}
+	}
+
+	return invocationTracker
+}
+
 func GenerateFunctionSpecification(invocationSlice Invocations, durationMinutes int) (*common.FunctionSpecification, bool) {
 
 	// sort from first to last invocation
@@ -177,7 +207,7 @@ func GenerateFunctionSpecification(invocationSlice Invocations, durationMinutes 
 	lastMinuteNumber := int(time.Duration(finalInvocation * float64(time.Second)).Minutes())
 	perMinuteCount := make([]int, lastMinuteNumber+1)
 
-	var previousInvocationTimestamp = 0.0
+	var previousInvocationTimestamp = -1.0
 
 	for _, invocation := range invocationSlice {
 		// truncate if function invocation ends after durationMinutes.

--- a/pkg/trace/azure2021_trace_parser_test.go
+++ b/pkg/trace/azure2021_trace_parser_test.go
@@ -59,8 +59,8 @@ func TestAzure2021ParserWrapper(t *testing.T) {
 		str := function.Name
 		if strings.Contains(str, substr) {
 			tolerance := 0.00001
-			if math.Abs(function.Specification.IAT[0]-1000000) > tolerance {
-				t.Errorf("Expected IAT value of 1000000, Got %f", function.Specification.IAT[0])
+			if math.Abs(function.Specification.IAT[0]-0) > tolerance {
+				t.Errorf("Expected IAT value of 0, Got %f", function.Specification.IAT[0])
 			} else if function.Specification.RuntimeSpecification[0].Runtime != 9000 {
 				t.Errorf("Expected Runtime value of 9000, Got %d", function.Specification.RuntimeSpecification[0].Runtime)
 			}
@@ -131,6 +131,39 @@ func TestAzure2021ParseCSVFile(t *testing.T) {
 		if math.Abs(invocation.duration-expectedDuration) > tolerance {
 			t.Errorf("Incorrect duration. Expected 9.0 got %f", invocation.duration)
 		}
+	}
+}
+
+func TestZeroInvocations(t *testing.T) {
+
+	// Input
+	inputTracker := make(map[UniqueFunctionID]Invocations)
+	inputTracker[UniqueFunctionID{"A", "1"}] = Invocations{
+		Invocation{1.0, 1.0},
+	}
+	inputTracker[UniqueFunctionID{"B", "2"}] = Invocations{
+		Invocation{4.0, 2.0},
+	}
+	inputTracker[UniqueFunctionID{"C", "3"}] = Invocations{
+		Invocation{5.0, 1.0},
+	}
+
+	// Output
+	expectedTracker := make(map[UniqueFunctionID]Invocations)
+	expectedTracker[UniqueFunctionID{"A", "1"}] = Invocations{
+		Invocation{0.0, 1.0},
+	}
+	expectedTracker[UniqueFunctionID{"B", "2"}] = Invocations{
+		Invocation{3.0, 2.0},
+	}
+	expectedTracker[UniqueFunctionID{"C", "3"}] = Invocations{
+		Invocation{4.0, 1.0},
+	}
+
+	resultTracker := ZeroInvocations(inputTracker)
+
+	if !reflect.DeepEqual(resultTracker, expectedTracker) {
+		t.Errorf("got %v, want %v", resultTracker, expectedTracker)
 	}
 }
 


### PR DESCRIPTION
## Summary

After invocations read from csv, subtracts all timestamps by the smallest timestamp.
Forces the first invocation to start immediately. 

## Implementation Notes :hammer_and_pick:

* After invocations are parsed but before function specifications are generated, `ZeroInvocations` finds the smallest invocation timestamp, and subtracts all timestamps by that invocation timestamp.
* Leaves `GenerateFunctionSpecification` `ParseCSVFile` mostly untouched.
* Minor changes in test functions to accommodate new expected output values.

## External Dependencies :four_leaf_clover:

none (N/A) 

## Breaking API Changes :warning:

* Earliest function invocation will fire immediately.
