### PR TITLE
Add zero-ing of Azure2021 filter function

### DIFF
--- a/.github/configs/wordlist.txt
+++ b/.github/configs/wordlist.txt
@@ -863,3 +863,4 @@ cmd
 convertIBM
 AsAzure
 ibm
+preprocessIBM

--- a/docs/loader.md
+++ b/docs/loader.md
@@ -68,7 +68,7 @@ $ bash ./scripts/util/check_node_capacity.sh
 ```
 
 If you want to check
-the [pod CIDR range](https://www.ibm.com/docs/en/cloud-private/3.1.2?topic=networking-kubernetes-network-model), run the
+the [pod CIDR range](https://www.redhat.com/en/blog/cni-kubernetes), run the
 following
 
 ```bash
@@ -176,7 +176,7 @@ To run `IBM2026` functions, the trace must be preprocessed and converted to an e
 
 ```bash
 # Extract excerpt (60 minutes starting from 1 hr) and convert 
-$ python -m sampler convertIBM2026 -t data/traces/ibm2026 -o data/traces/ibm2026/output -s 00:01:00 -dur 60
+$ python -m sampler preprocessIBM2026 -t data/traces/ibm2026 -o data/traces/ibm2026/output -s 00:01:00 -dur 60
 ```
 The trace is now in the `Azure2021` format, and can be optionally sub-sampled further, following the instructions in [Azure2021](sampler.md##using-azure2021-traces). Finally, run the following to load the trace:
 

--- a/docs/sampler.md
+++ b/docs/sampler.md
@@ -175,7 +175,7 @@ in [`plotTimeline/analysis.ipynb`](/tools/plotTimeline/analysis.ipynb)
 The sampling process of Azure2021 trace follows 3 steps: 
 1. Pre-process the original trace (`preprocess2021`) -> obtain clean trace in azure2019 format.
 2. Run the sampler on cleaned trace (`sampler`) -> obtain down-sampled trace, which contains a list of functions to keep in azure2019 format.
-3. Filter the original trace for functions in list (`filter`) -> obtain down-sampled and zero-ed trace in azure2021 format (per-invocation format).
+3. Filter the original trace for functions in list (`filter`) -> obtain down-sampled and timestamp normalized in azure2021 format (per-invocation format).
 
 Functionality of modules emulates the normal azure2019 modules, the differences is discussed below.
 
@@ -262,7 +262,7 @@ The preprocessing follows 3 steps:
 3. Transform the trace to azure2019 format. 
 
 ## Using IBM2026 Traces
-IBM2026 traces are supported by transforming it into Azure2021 format in `convertIBM2026`.
+IBM2026 traces are supported by transforming it into Azure2021 format in `preprocessIBM2026`.
 It is then treated as an Azure2021 trace in InVitro for Sampler and Loader. 
 
 ### Folder structure
@@ -284,7 +284,7 @@ invitro/data/traces/
 ### Workflow
 It should be noted that the `InvocationTimes` in IBM2026 appears to have a zero offset of 4 hours, 59 minutes, 59 seconds.
 For example, `week_1.pickle` contains timestamps from 0 days, 4:59:59 to 7 days 4:59:59.
-This offset is handled internally within `convertIBM2026`, timings for `-s` will start from 0 days, 4:59:59.
+This offset is handled internally within `preprocessIBM2026`, timings for `-s` will start from 0 days, 4:59:59.
 
 The below conversion will:
 - Convert the trace to `azure2021` format.
@@ -293,7 +293,7 @@ The below conversion will:
 
 Example conversion:
 ```Bash
-$ python -m sampler convertIBM2026 -t data/traces/ibm2026 -o data/traces/ibm2026/output -s 00:01:00 -dur 60
+$ python -m sampler preprocessIBM2026 -t data/traces/ibm2026 -o data/traces/ibm2026/output -s 00:01:00 -dur 60
 ```
 
 The output trace can then either:

--- a/docs/sampler.md
+++ b/docs/sampler.md
@@ -197,7 +197,7 @@ While `inv_df` and `dur_df` can be calculated, `mem_df` is set to a static value
 Filter first filters for invocations in the original trace within the time interval. 
 It then tracks all `HashApp` and `HashFunction` in the sampled trace. 
 Using that, it filters the original trace and keeps all functions that appear in the sampled trace (matching `app` and `func` values with `HashApp` and `HashFunction` values).
-The `start_timestamp` and `end_timestamp` are also zero-ed. This is achieved by subtracting the smallest `start_timestamp` value from both timestamp columns.
+The `start_timestamp` and `end_timestamp` are also zero-ed to `start_time` string argument. This is achieved by converting the `start_time` value into a time-delta, and subtracting it from both timestamp columns.
 
 ### Workflow
 

--- a/docs/sampler.md
+++ b/docs/sampler.md
@@ -175,7 +175,7 @@ in [`plotTimeline/analysis.ipynb`](/tools/plotTimeline/analysis.ipynb)
 The sampling process of Azure2021 trace follows 3 steps: 
 1. Pre-process the original trace (`preprocess2021`) -> obtain clean trace in azure2019 format.
 2. Run the sampler on cleaned trace (`sampler`) -> obtain down-sampled trace, which contains a list of functions to keep in azure2019 format.
-3. Filter the original trace for functions in list (`filter`) -> obtain down-sampled trace in azure2021 format (per-invocation format).
+3. Filter the original trace for functions in list (`filter`) -> obtain down-sampled and zero-ed trace in azure2021 format (per-invocation format).
 
 Functionality of modules emulates the normal azure2019 modules, the differences is discussed below.
 
@@ -194,9 +194,10 @@ While `inv_df` and `dur_df` can be calculated, `mem_df` is set to a static value
 
 ### Filter
 
-Filter first filters for invocations in original trace within the time interval. 
-It then tracks all `HashApp` and `HashFunction` in sampled trace. 
-Using that, it filters the original trace and keeps all invocations with matching `app` and `func` values.
+Filter first filters for invocations in the original trace within the time interval. 
+It then tracks all `HashApp` and `HashFunction` in the sampled trace. 
+Using that, it filters the original trace and keeps all functions that appear in the sampled trace (matching `app` and `func` values with `HashApp` and `HashFunction` values).
+The `start_timestamp` and `end_timestamp` are also zero-ed. This is achieved by subtracting the smallest `start_timestamp` value from both timestamp columns.
 
 ### Workflow
 

--- a/sampler/filter.py
+++ b/sampler/filter.py
@@ -47,6 +47,9 @@ def filter_azure2021(orig_trace_path: str, sampled_trace_dir: str, out_dir: str,
     functions_to_keep_keys = inv_df[['app', 'func']].drop_duplicates()
     trace_df = trace_df.merge(functions_to_keep_keys, on=['app', 'func'], how='inner')
 
+    # Zero to earliest start_timestamp
+    trace_df = zero_timestamps(trace_df)
+
     # Cleanup
     trace_df = trace_df.drop(columns=['start_timestamp'])
 
@@ -61,3 +64,22 @@ def filter_azure2021(orig_trace_path: str, sampled_trace_dir: str, out_dir: str,
         
     log.info(f"Saving sampled Azure2021 to {out_dir}/SampledAzure2021.csv")
     trace_df.to_csv(f"{out_dir}/SampledAzure2021.csv", index=False)
+
+# Subtracts 'end_timestamp' and 'start_timestamp' by the smallest 'start_timestamp' value.
+def zero_timestamps(df: pd.DataFrame) -> pd.DataFrame:
+
+    if len(df.index) == 0:
+        return df
+
+    # Obtain smallest time_delta (new zero)
+    smallest_td = df['start_timestamp'].min()
+
+    # Zero timestamps
+    df['end_timestamp'] = pd.to_timedelta(df['end_timestamp'], unit='s') - smallest_td
+    df['start_timestamp'] = pd.to_timedelta(df['start_timestamp'], unit='s') - smallest_td
+
+    # Return to original float type
+    df['end_timestamp'] = df['end_timestamp'].dt.total_seconds()
+
+    return df
+    

--- a/sampler/filter.py
+++ b/sampler/filter.py
@@ -47,8 +47,8 @@ def filter_azure2021(orig_trace_path: str, sampled_trace_dir: str, out_dir: str,
     functions_to_keep_keys = inv_df[['app', 'func']].drop_duplicates()
     trace_df = trace_df.merge(functions_to_keep_keys, on=['app', 'func'], how='inner')
 
-    # Zero to earliest start_timestamp
-    trace_df = zero_timestamps(trace_df)
+    # Zero to start_time
+    trace_df = zero_timestamps(trace_df, start_time)
 
     # Cleanup
     trace_df = trace_df.drop(columns=['start_timestamp'])
@@ -65,21 +65,31 @@ def filter_azure2021(orig_trace_path: str, sampled_trace_dir: str, out_dir: str,
     log.info(f"Saving sampled Azure2021 to {out_dir}/SampledAzure2021.csv")
     trace_df.to_csv(f"{out_dir}/SampledAzure2021.csv", index=False)
 
-# Subtracts 'end_timestamp' and 'start_timestamp' by the smallest 'start_timestamp' value.
-def zero_timestamps(df: pd.DataFrame) -> pd.DataFrame:
+# Subtracts 'end_timestamp' and 'start_timestamp' by the time delta of 'start_duration'.
+def zero_timestamps(df: pd.DataFrame, start_time: str) -> pd.DataFrame:
 
     if len(df.index) == 0:
         return df
 
-    # Obtain smallest time_delta (new zero)
-    smallest_td = df['start_timestamp'].min()
+    # Obtain time_delta of start_time
+    new_zero_td = start_time_to_time_delta(start_time)
 
     # Zero timestamps
-    df['end_timestamp'] = pd.to_timedelta(df['end_timestamp'], unit='s') - smallest_td
-    df['start_timestamp'] = pd.to_timedelta(df['start_timestamp'], unit='s') - smallest_td
+    df['end_timestamp'] = pd.to_timedelta(df['end_timestamp'], unit='s') - new_zero_td
+    df['start_timestamp'] = pd.to_timedelta(df['start_timestamp'], unit='s') - new_zero_td
 
     # Return to original float type
     df['end_timestamp'] = df['end_timestamp'].dt.total_seconds()
 
     return df
     
+def start_time_to_time_delta(start_time: str) -> pd.Timedelta:
+
+    # Parse string + determine Timedelta
+    start_time = start_time.split(":")
+    day = int(start_time[0])
+    hours = int(start_time[1])
+    minutes = int(start_time[2])
+
+    interval_start = pd.Timedelta(days=day, hours=hours, minutes=minutes)
+    return interval_start

--- a/sampler/preprocess2021.py
+++ b/sampler/preprocess2021.py
@@ -68,12 +68,11 @@ def preprocess_file(trace_path: str, start_time: str, duration: str, output_dir:
     mem_df.to_csv(f"{output_dir}/memory.csv", index=False)
     dur_df.to_csv(f"{output_dir}/durations.csv", index=False)
 
-# Filter for invocation from [start_time, start_time+duration_mintues)
+# Filter for invocation's start timestamp from [start_time, start_time+duration_mintues)
 def filter_within_time_interval(df: pd.DataFrame, start_time: str, duration_minutes: str) -> Tuple[pd.DataFrame, pd.Timedelta, pd.Timedelta]:
     
     # Generate start time
-    df['start_timestamp'] = df['end_timestamp'] - df['duration']
-    df['start_timestamp'] = pd.to_timedelta(df['start_timestamp'], unit='s')
+    df['start_timestamp'] = pd.to_timedelta(df['end_timestamp'], unit='s') - pd.to_timedelta(df['duration'], unit='s')
 
     # Determine time interval
     start_time = start_time.split(":")

--- a/sampler/tests/filter_test.py
+++ b/sampler/tests/filter_test.py
@@ -91,7 +91,7 @@ def test_azure2021_filter(tmp_path):
         {
             "app":           ["aa", "ab", "ac", "ac"],
             "func":          ["fa", "fb", "fd", "fd"],
-            "end_timestamp": [ 1.0, 10.0, 100.0, 300.0], # All zeroed to start_time's Timedelta of 0
+            "end_timestamp": [ 1.0, 10.0, 100.0, 300.0],
             "duration":      [0.50,  5.0,  40.0, 100.0],
         # "start_timestamp": [0.50,  5.0,  60.0, 200.0]
         }
@@ -109,7 +109,7 @@ def test_same_app_different_functions(tmp_path):
         {
             "app":           ["aa", "ab", "ac",  "ac"],
             "func":          ["fa", "fb", "fa",  "fb"],
-            "end_timestamp": [1.00, 10.0, 80.0, 100.0], # 5 Minutes, 0-300 seconds
+            "end_timestamp": [1.00, 10.0, 80.0, 100.0],
             "duration":      [0.50,  5.0, 15.5,  40.0],
         # "start_timestamp": [0.50,  5.0, 64.5,  60.0]
         }
@@ -162,9 +162,9 @@ def test_zero_to_start_time(tmp_path):
         {
             "app":           ["ac",  "ac"],
             "func":          ["fa",  "fb"],
-            "end_timestamp": [80.0, 100.0], # 4 Minutes, 60-300 seconds
-            "duration":      [15.5,  40.0],
-        # "start_timestamp": [64.5,  60.0]
+            "end_timestamp": [80.0, 100.0],
+            "duration":      [15.5,  20.0],
+        # "start_timestamp": [64.5,  80.0]
         }
     )
     orig_trace_path = create_original_df_file(tmp_path, og_df)
@@ -199,10 +199,10 @@ def test_zero_to_start_time(tmp_path):
         {
             "app":           ["ac",  "ac"],
             "func":          ["fa",  "fb"],
-            "end_timestamp": [20.0,  40.0], 
-        #   "end_timestamp": [80.0, 100.0], Before
-            "duration":      [15.5,  40.0],
-        # "start_timestamp": [ 4.5,  0.00]
+            "end_timestamp": [20.0,  40.0],# After normalisation 
+        #   "end_timestamp": [80.0, 100.0],  Before normalisation
+            "duration":      [15.5,  20.0],
+        # "start_timestamp": [ 4.5,  20.0]
         }
     )
 

--- a/sampler/tests/filter_test.py
+++ b/sampler/tests/filter_test.py
@@ -91,7 +91,7 @@ def test_azure2021_filter(tmp_path):
         {
             "app":           ["aa", "ab", "ac", "ac"],
             "func":          ["fa", "fb", "fd", "fd"],
-            "end_timestamp": [0.50,  9.5,  99.5, 299.5], # All zeroed to smallest start_timestamp of 0.5
+            "end_timestamp": [ 1.0, 10.0, 100.0, 300.0], # All zeroed to start_time's Timedelta of 0
             "duration":      [0.50,  5.0,  40.0, 100.0],
         # "start_timestamp": [0.50,  5.0,  60.0, 200.0]
         }
@@ -146,7 +146,7 @@ def test_same_app_different_functions(tmp_path):
         {
             "app":           ["aa",  "ac",  "ac"],
             "func":          ["fa",  "fa",  "fb"],
-            "end_timestamp": [0.50,  79.5,  99.5],
+            "end_timestamp": [1.00,  80.0, 100.0],
             "duration":      [0.50,  15.5,  40.0],
         # "start_timestamp": [0.50,  64.5,  60.0]
         }
@@ -154,3 +154,56 @@ def test_same_app_different_functions(tmp_path):
 
     pd.testing.assert_frame_equal(filtered_df, expected_filtered_df)
 
+# - Test that output DF zeros to start_time
+def test_zero_to_start_time(tmp_path):
+
+    # Original DF
+    og_df = pd.DataFrame(
+        {
+            "app":           ["ac",  "ac"],
+            "func":          ["fa",  "fb"],
+            "end_timestamp": [80.0, 100.0], # 4 Minutes, 60-300 seconds
+            "duration":      [15.5,  40.0],
+        # "start_timestamp": [64.5,  60.0]
+        }
+    )
+    orig_trace_path = create_original_df_file(tmp_path, og_df)
+
+    # Sampled DF
+    inv_df = pd.DataFrame(
+        {
+            "HashApp":      ["ac", "ac"],
+            "HashFunction": ["fa", "fb"],
+            "HashOwner":    ["oc", "oc"],
+            "Trigger":      ["tr", "tr"],
+            "1":            [   0,    0],
+            "2":            [   1,    1],
+            "3":            [   0,    0],
+            "4":            [   0,    0],
+            "5":            [   0,    0],
+        }
+    )
+    sampled_trace_dir = create_sampled_df_file(tmp_path, inv_df)
+
+    out_dir = tmp_path / "output"
+    start_time = "00:00:01"
+    duration = 4
+    
+    filter_azure2021(orig_trace_path, sampled_trace_dir, str(out_dir), start_time, duration)
+
+    # Read and compare output filtered_DF
+    filtered_df_path = out_dir / "SampledAzure2021.csv"
+    filtered_df = pd.read_csv(filtered_df_path)
+
+    expected_filtered_df = pd.DataFrame(
+        {
+            "app":           ["ac",  "ac"],
+            "func":          ["fa",  "fb"],
+            "end_timestamp": [20.0,  40.0], 
+        #   "end_timestamp": [80.0, 100.0], Before
+            "duration":      [15.5,  40.0],
+        # "start_timestamp": [ 4.5,  0.00]
+        }
+    )
+
+    pd.testing.assert_frame_equal(filtered_df, expected_filtered_df)

--- a/sampler/tests/filter_test.py
+++ b/sampler/tests/filter_test.py
@@ -91,7 +91,7 @@ def test_azure2021_filter(tmp_path):
         {
             "app":           ["aa", "ab", "ac", "ac"],
             "func":          ["fa", "fb", "fd", "fd"],
-            "end_timestamp": [1.00, 10.0, 100.0, 300.0],
+            "end_timestamp": [0.50,  9.5,  99.5, 299.5], # All zeroed to smallest start_timestamp of 0.5
             "duration":      [0.50,  5.0,  40.0, 100.0],
         # "start_timestamp": [0.50,  5.0,  60.0, 200.0]
         }
@@ -146,7 +146,7 @@ def test_same_app_different_functions(tmp_path):
         {
             "app":           ["aa",  "ac",  "ac"],
             "func":          ["fa",  "fa",  "fb"],
-            "end_timestamp": [1.00,  80.0, 100.0],
+            "end_timestamp": [0.50,  79.5,  99.5],
             "duration":      [0.50,  15.5,  40.0],
         # "start_timestamp": [0.50,  64.5,  60.0]
         }


### PR DESCRIPTION
## Summary
* Zeros the resultant azure2021 trace to the smallest `start_timestamp` value.

## Implementation Notes :hammer_and_pick:

* Add in `zero_timestamps` function in filter.py
* After keeping functions present in both sampled and original trace, subtracts the smallest `start_timestamp` value from both `start_timestamp` and `end_timestamp` columns.

## External Dependencies :four_leaf_clover:

none (N/A)

## Breaking API Changes :warning:

none (N/A)
